### PR TITLE
Party description update

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
+extension-pkg-whitelist=lxml
 
 # Specify a score threshold to be exceeded before program exits with error.
 fail-under=10

--- a/conf/conf.py
+++ b/conf/conf.py
@@ -8,3 +8,7 @@ MAX_CONSECUTIVE_FAILS = 5
 
 # Habitica UID of the administrator
 ADMIN_UID = "f687a6c7-860a-4c7c-8a07-9d0dcbb7c831"  # Antonbury
+
+# Wiki page containing information about the party:
+PARTY_WIKI_URL = ("https://habitica.fandom.com/wiki/"
+                  "The_Keep:Mental_Health_Warriors_Unite")

--- a/conf/secrets/habitica_credentials_template.py
+++ b/conf/secrets/habitica_credentials_template.py
@@ -3,11 +3,21 @@ Keep the contents of this file private! User ID is public information, but API
 token is as powerful as your password.
 """
 
-# Replace yourUID with your user ID (keep the quotes). If you need help
-# determining it, see
+# Replace your-user-id-here with your user ID (keep the quotes). If you need
+# help determining it, see
 # https://habitica.fandom.com/wiki/API_Options#User_ID_.28UID.29
 PLAYER_USER_ID = "your-user-id-here"
 
-# Replaser yourToken with your API token (keep the quotes). For help, see
-# https://habitica.fandom.com/wiki/API_Options#API_Token
+# Replace your-api-token-here with your API token (keep the quotes). For help,
+# see https://habitica.fandom.com/wiki/API_Options#API_Token
 PLAYER_API_TOKEN = "your-api-token-here"
+
+# User ID for the party owner. Setting values for these is only necessary if
+# the bot is not the owner of the party and features requiring party owner
+# privileges (e.g. updating the party description) are used.
+PARTY_OWNER_USER_ID = None
+
+# API token for the party owner. Setting values for these is only necessary if
+# the bot is not the owner of the party and features requiring party owner
+# privileges (e.g. updating the party description) are used.
+PARTY_OWNER_API_TOKEN = None

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -216,19 +216,19 @@ class UpdatePartyDescription(Functionality):
 
         The data is fetched from an unordered list in the wiki page, identified
         by it containing an item containing "(CURRENT)". It is returned in
-        Habitica ordered list format with the first quest shown as the
-        "zeroeth", e.g.
+        Habitica ordered list format with the first quest shown outside the
+        list, e.g.
         ```
         The Quest Queue (as in Wiki on Apr 24 at 14:18 UTC):
 
-         0. (CURRENT) Wind-Up Hatching Potions (Boss 1000)
+         (CURRENT) Wind-Up Hatching Potions (Boss 1000)
          1. Dolphin (Boss 300)
-         2. Seahorse (Boss 300)
-         3. Monkey (Boss 400)
-         4. Cheetah (Boss 600)
-         5. Kangaroo (Boss 700)
-         6. Silver Hatching Potions (collection)
-         7. Ferret (Boss 400)
+         1. Seahorse (Boss 300)
+         1. Monkey (Boss 400)
+         1. Cheetah (Boss 600)
+         1. Kangaroo (Boss 700)
+         1. Silver Hatching Potions (collection)
+         1. Ferret (Boss 400)
         ```
 
         :returns: A string containing the current quest queue.
@@ -240,8 +240,12 @@ class UpdatePartyDescription(Functionality):
                                    "wiki page {} failed: {} queue candidates "
                                    "found.".format(conf.PARTY_WIKI_URL,
                                                    len(ols)))
-        quest_queue_items = ["{}. {}".format(i, li.text)
-                             for i, li in enumerate(ols[0].getchildren())]
+        list_items = ols[0].getchildren()
+        quest_queue_items = []
+        quest_queue_items.append(list_items[0].text)
+        for item in list_items[1:]:
+            quest_queue_items.append("1. {}".format(item.text))
+
         current_time = datetime.datetime.now()
         quest_queue_lines = (
                 ["The Quest Queue (as in Wiki on {}):\n"

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -203,7 +203,7 @@ class UpdatePartyDescription(Functionality):
         return ("Old description:\n\n"
                 "{}\n"
                 "---\n\n"
-                "New description:\n"
+                "New description:\n\n"
                 "{}"
                 "".format(old_description, new_description))
 
@@ -244,7 +244,7 @@ class UpdatePartyDescription(Functionality):
                              for i, li in enumerate(ols[0].getchildren())]
         current_time = datetime.datetime.now()
         quest_queue_lines = (
-                ["The Quest Queue (as in Wiki on {}):"
+                ["The Quest Queue (as in Wiki on {}):\n"
                  "".format(current_time.strftime("%b %d at %H:%M UTC%z"))]
                 + quest_queue_items)
         return "\n".join(quest_queue_lines)

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -22,6 +22,7 @@ from conf.header import HEADER
 from conf.tasks import WINNER_PICKED
 from conf.sharing_weekend import STOCK_DAY_NUMBER, STOCK_NAME
 from conf import conf
+from conf.secrets import habitica_credentials
 
 
 def handle_PMs():
@@ -200,8 +201,14 @@ class UpdatePartyDescription(Functionality):
         old_description = self._partytool.party_description()
         new_queue = self._parse_quest_queue_from_wiki()
         new_description = self._replace_quest_queue(old_description, new_queue)
-        return ("Old description:\n\n"
+        self._partytool.update_party_description(
+                new_description,
+                user_id=habitica_credentials.PARTY_OWNER_USER_ID,
+                user_api_token=habitica_credentials.PARTY_OWNER_API_TOKEN)
+        return ("Updated the party description. Old description:\n\n"
+                "```\n"
                 "{}\n"
+                "```\n"
                 "---\n\n"
                 "New description:\n\n"
                 "{}"

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -216,16 +216,16 @@ class UpdatePartyDescription(Functionality):
 
         The data is fetched from an unordered list in the wiki page, identified
         by it containing an item containing "(CURRENT)". It is returned in
-        Habitica list format, e.g.
+        Habitica ordered list format, e.g.
         ```
-         - (CURRENT) Wind-Up Hatching Potions (Boss 1000)
-         - 1) Dolphin (Boss 300)
-         - 2) Seahorse (Boss 300)
-         - 3) Monkey (Boss 400)
-         - 4) Cheetah (Boss 600)
-         - 5) Kangaroo (Boss 700)
-         - 6) Silver Hatching Potions (collection)
-         - 7) Ferret (Boss 400)
+         1. (CURRENT) Wind-Up Hatching Potions (Boss 1000)
+         1. Dolphin (Boss 300)
+         1. Seahorse (Boss 300)
+         1. Monkey (Boss 400)
+         1. Cheetah (Boss 600)
+         1. Kangaroo (Boss 700)
+         1. Silver Hatching Potions (collection)
+         1. Ferret (Boss 400)
         ```
 
         :returns: A string containing the current quest queue.
@@ -237,7 +237,7 @@ class UpdatePartyDescription(Functionality):
                                    "wiki page {} failed: {} queue candidates "
                                    "found.".format(conf.PARTY_WIKI_URL,
                                                    len(uls)))
-        quest_queue_items = [" - {}".format(li.text)
+        quest_queue_items = ["1. {}".format(li.text)
                              for li in uls[0].getchildren()]
         current_time = datetime.datetime.now()
         quest_queue_lines = (

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -181,6 +181,15 @@ class UpdatePartyDescription(Functionality):
         """
         self._partytool = habiticatool.PartyTool(HEADER)
         self._wikireader = WikiReader(conf.PARTY_WIKI_URL)
+        super().__init__()
+
+    def help(self):
+        """
+        Return a help string
+        """
+        # pylint: disable=no-self-use
+        return ("Fetch new quest queue from the party wiki page and update it "
+                "to the party description.")
 
     def act(self, message):
         """

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -240,7 +240,7 @@ class UpdatePartyDescription(Functionality):
                                    "wiki page {} failed: {} queue candidates "
                                    "found.".format(conf.PARTY_WIKI_URL,
                                                    len(ols)))
-        quest_queue_items = ["{}. {}".format(i-1, li.text)
+        quest_queue_items = ["{}. {}".format(i, li.text)
                              for i, li in enumerate(ols[0].getchildren())]
         current_time = datetime.datetime.now()
         quest_queue_lines = (

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -246,10 +246,10 @@ class UpdatePartyDescription(Functionality):
         for item in list_items[1:]:
             quest_queue_items.append("1. {}".format(item.text))
 
-        current_time = datetime.datetime.now()
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         quest_queue_lines = (
                 ["The Quest Queue (as in Wiki on {}):\n"
-                 "".format(current_time.strftime("%b %d at %H:%M UTC%z"))]
+                 "".format(current_time.strftime("%b %d at %H:%M %z"))]
                 + quest_queue_items)
         return "\n".join(quest_queue_lines)
 

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -216,16 +216,19 @@ class UpdatePartyDescription(Functionality):
 
         The data is fetched from an unordered list in the wiki page, identified
         by it containing an item containing "(CURRENT)". It is returned in
-        Habitica ordered list format, e.g.
+        Habitica ordered list format with the first quest shown as the
+        "zeroeth", e.g.
         ```
-         1. (CURRENT) Wind-Up Hatching Potions (Boss 1000)
+        The Quest Queue (as in Wiki on Apr 24 at 14:18 UTC):
+
+         0. (CURRENT) Wind-Up Hatching Potions (Boss 1000)
          1. Dolphin (Boss 300)
-         1. Seahorse (Boss 300)
-         1. Monkey (Boss 400)
-         1. Cheetah (Boss 600)
-         1. Kangaroo (Boss 700)
-         1. Silver Hatching Potions (collection)
-         1. Ferret (Boss 400)
+         2. Seahorse (Boss 300)
+         3. Monkey (Boss 400)
+         4. Cheetah (Boss 600)
+         5. Kangaroo (Boss 700)
+         6. Silver Hatching Potions (collection)
+         7. Ferret (Boss 400)
         ```
 
         :returns: A string containing the current quest queue.
@@ -237,8 +240,8 @@ class UpdatePartyDescription(Functionality):
                                    "wiki page {} failed: {} queue candidates "
                                    "found.".format(conf.PARTY_WIKI_URL,
                                                    len(ols)))
-        quest_queue_items = ["1. {}".format(li.text)
-                             for li in ols[0].getchildren()]
+        quest_queue_items = ["{}. {}".format(i-1, li.text)
+                             for i, li in enumerate(ols[0].getchildren())]
         current_time = datetime.datetime.now()
         quest_queue_lines = (
                 ["The Quest Queue (as in Wiki on {}):"

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -205,7 +205,7 @@ class UpdatePartyDescription(Functionality):
         self._partytool.update_party_description(
                 new_description,
                 user_id=habitica_credentials.PARTY_OWNER_USER_ID,
-                user_api_token=habitica_credentials.PARTY_OWNER_API_TOKEN)
+                api_token=habitica_credentials.PARTY_OWNER_API_TOKEN)
         return ("Updated the party description. Old description:\n\n"
                 "```\n"
                 "{}\n"

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -254,7 +254,7 @@ class UpdatePartyDescription(Functionality):
         current_time = datetime.datetime.now(datetime.timezone.utc)
         quest_queue_lines = (
                 ["The Quest Queue (as in Wiki on {}):\n"
-                 "".format(current_time.strftime("%b %d at %H:%M %z"))]
+                 "".format(current_time.strftime("%b %d at %H:%M UTC%z"))]
                 + quest_queue_items)
         return "\n".join(quest_queue_lines)
 

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -263,6 +263,7 @@ class UpdatePartyDescription(Functionality):
         Return the old description with everything in it starting with "The
         Quest queue" replaced with the given new_queue.
         """
+        # pylint: disable=no-self-use
         return old_description.split("The Quest Queue ")[0] + new_queue
 
 

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -230,15 +230,15 @@ class UpdatePartyDescription(Functionality):
 
         :returns: A string containing the current quest queue.
         """
-        uls = self._wikireader.find_elements_with_matching_subelement(
-                "ul", "(CURRENT)")
-        if len(uls) != 1:
+        ols = self._wikireader.find_elements_with_matching_subelement(
+                "ol", "(CURRENT)")
+        if len(ols) != 1:
             raise WikiParsingError("Identifying a single quest queue in party "
                                    "wiki page {} failed: {} queue candidates "
                                    "found.".format(conf.PARTY_WIKI_URL,
-                                                   len(uls)))
+                                                   len(ols)))
         quest_queue_items = ["1. {}".format(li.text)
-                             for li in uls[0].getchildren()]
+                             for li in ols[0].getchildren()]
         current_time = datetime.datetime.now()
         quest_queue_lines = (
                 ["The Quest Queue (as in Wiki on {}):"

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -192,6 +192,7 @@ class UpdatePartyDescription(Functionality):
         return ("Fetch new quest queue from the party wiki page and update it "
                 "to the party description.")
 
+    @requires_party_membership
     def act(self, message):
         """
         Update the quest queue in party description.

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -22,7 +22,17 @@ from conf.header import HEADER
 from conf.tasks import WINNER_PICKED
 from conf.sharing_weekend import STOCK_DAY_NUMBER, STOCK_NAME
 from conf import conf
-from conf.secrets import habitica_credentials
+
+try:
+    # It's okay for the secrets not to be in place during testing: they are
+    # mocked.
+    # pylint: disable=no-name-in-module
+    from conf.secrets import habitica_credentials
+except ImportError:
+    habot.logger.get_logger().error(
+            "Credential file not found. If you are trying to use "
+            "the bot instead of just running unit tests, please "
+            "see readme and properly set Habitica credentials.")
 
 
 def handle_PMs():

--- a/habot/bot.py
+++ b/habot/bot.py
@@ -216,19 +216,19 @@ class UpdatePartyDescription(Functionality):
 
         The data is fetched from an unordered list in the wiki page, identified
         by it containing an item containing "(CURRENT)". It is returned in
-        Habitica ordered list format with the first quest shown outside the
-        list, e.g.
+        Habitica ordered list format with the first quest shown as the
+        "zeroeth", e.g.
         ```
         The Quest Queue (as in Wiki on Apr 24 at 14:18 UTC):
 
-         (CURRENT) Wind-Up Hatching Potions (Boss 1000)
+         0. (CURRENT) Wind-Up Hatching Potions (Boss 1000)
          1. Dolphin (Boss 300)
-         1. Seahorse (Boss 300)
-         1. Monkey (Boss 400)
-         1. Cheetah (Boss 600)
-         1. Kangaroo (Boss 700)
-         1. Silver Hatching Potions (collection)
-         1. Ferret (Boss 400)
+         2. Seahorse (Boss 300)
+         3. Monkey (Boss 400)
+         4. Cheetah (Boss 600)
+         5. Kangaroo (Boss 700)
+         6. Silver Hatching Potions (collection)
+         7. Ferret (Boss 400)
         ```
 
         :returns: A string containing the current quest queue.
@@ -240,11 +240,8 @@ class UpdatePartyDescription(Functionality):
                                    "wiki page {} failed: {} queue candidates "
                                    "found.".format(conf.PARTY_WIKI_URL,
                                                    len(ols)))
-        list_items = ols[0].getchildren()
-        quest_queue_items = []
-        quest_queue_items.append(list_items[0].text)
-        for item in list_items[1:]:
-            quest_queue_items.append("1. {}".format(item.text))
+        quest_queue_items = ["{}. {}".format(i, li.text)
+                             for i, li in enumerate(ols[0].getchildren())]
 
         current_time = datetime.datetime.now(datetime.timezone.utc)
         quest_queue_lines = (

--- a/habot/io.py
+++ b/habot/io.py
@@ -6,6 +6,8 @@ Currently this means interacting via private or party messages in Habitica.
 
 from collections import OrderedDict
 from datetime import datetime
+from io import StringIO
+from lxml import etree
 import requests.exceptions
 import yaml
 
@@ -644,6 +646,69 @@ class YAMLFileIO():
                       default_flow_style=False)
 
 
+class WikiReader():
+    """
+    Tool for fetching content of a page from Habitica wiki.
+    """
+
+    def __init__(self, url):
+        """
+        Initialize the object
+
+        :url: String containing url to the page, e.g.
+              "https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite".
+        """
+        self.url = url
+        self._parser = etree.HTMLParser()
+        self._page = None
+
+    class Decorators():
+        """
+        Decorators used by WikiReader
+        """
+        # pylint: disable=too-few-public-methods
+
+        @classmethod
+        def needs_page(cls, method):
+            """
+            Decorator for functions that need the page to be fetched
+            """
+            def _decorated(*args, **kwargs):
+                # pylint: disable=protected-access
+                if not args[0]._page:
+                    args[0]._read_page()
+                return method(*args, **kwargs)
+            return _decorated
+
+    def _read_page(self):
+        """
+        Fetch the page from the wiki.
+
+        :raise:
+            :HTTPError: if the page cannot be fetched
+            :WikiParsingError: if the page content cannot be found
+        """
+        response = requests.get(self.url)
+        response.raise_for_status()
+        full_page_tree = etree.parse(StringIO(str(response.content)),
+                                     self._parser)
+        content = full_page_tree.getroot().cssselect(".WikiaPage")
+        if len(content) != 1:
+            raise WikiParsingError("More than one `WikiaPage` element "
+                                   "encountered")
+        self._page = content[0]
+
+    @property
+    @Decorators.needs_page
+    def page(self):
+        """
+        Return the HTML contents of the page as lxml ElementTree.
+        :returns: lxml Element corresponding to the root node of the wiki page
+                  content.
+        """
+        return self._page
+
+
 class MalformedQuestionFileException(Exception):
     """
     Exception raised when the question list cannot be parsed.
@@ -682,4 +747,9 @@ class UnsplittableMessage(Exception):
 class SpamDetected(Exception):
     """
     Exception for situations where the spot is being used for spamming.
+    """
+
+class WikiParsingError(Exception):
+    """
+    Exception for unexpected content from Habitica Wiki.
     """

--- a/habot/io.py
+++ b/habot/io.py
@@ -708,6 +708,31 @@ class WikiReader():
         """
         return self._page
 
+    @Decorators.needs_page
+    def find_elements_with_matching_subelement(self, element_selector,
+                                               child_text):
+        """
+        Return a list of elements of given type that have a matching children.
+
+        The given `child_text` must only be present in one of the children
+        elements: it is not necessary for it to be the full content of the
+        element.
+
+        :element_selector: CSS selector for finding the elements. E.g. `div` or
+                           `#someid` or `ul.navigation`.
+        :child_text: A string that must be found in the content of at least one
+                     of the child elements.
+        :returns: A list of lxml ElementTrees, each startig from an element
+                  that matched the search criteria.
+        """
+        css_matching_elements = self._page.cssselect(element_selector)
+        full_match_elements = []
+        for element in css_matching_elements:
+            for child in element.iterchildren():
+                if child.text and child_text in child.text:
+                    full_match_elements.append(element)
+        return full_match_elements
+
 
 class MalformedQuestionFileException(Exception):
     """
@@ -748,6 +773,7 @@ class SpamDetected(Exception):
     """
     Exception for situations where the spot is being used for spamming.
     """
+
 
 class WikiParsingError(Exception):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 click
+cssselect
 git+git://github.com/aajarven/habitica-helper.git#egg=habitica-helper
 google-api-python-client
 google-auth-httplib2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ git+git://github.com/aajarven/habitica-helper.git#egg=habitica-helper
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
+lxml
 mysql-connector-python
 pyyaml
 requests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,5 +13,6 @@ pyyaml
 requests
 requests_mock
 schedule
+surrogate
 testing.mysqld
 yfinance

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 click
+cssselect
 freezegun
 git+git://github.com/aajarven/habitica-helper.git#egg=habitica-helper
 google-api-python-client

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,7 @@ git+git://github.com/aajarven/habitica-helper.git#egg=habitica-helper
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
+lxml
 mysql-connector-python
 pytest
 pytest-mock

--- a/run-scheduled.py
+++ b/run-scheduled.py
@@ -9,11 +9,12 @@ import schedule
 
 from conf.header import HEADER
 from conf import conf
+from conf.secrets import habitica_credentials
 from habot.birthdays import BirthdayReminder
 from habot.bot import (handle_PMs, SendWinnerMessage, AwardWinner,
                        CreateNextSharingWeekend, UpdatePartyDescription)
 from habot.exceptions import CommunicationFailedException
-from habot.io import HabiticaMessager
+from habot.io import HabiticaMessager, PrivateMessage
 from habot.habitica_operations import HabiticaOperator
 from habot.logger import get_logger
 
@@ -24,7 +25,9 @@ def update_party_description():
 
     This is done silently: if everything works as intended, nobody is notified.
     """
-    result = UpdatePartyDescription().act("update-party-description")
+    fake_request_message = PrivateMessage(habitica_credentials.PLAYER_USER_ID,
+                                          habitica_credentials.PLAYER_USER_ID)
+    result = UpdatePartyDescription().act(fake_request_message)
     get_logger().info(result)
 
 

--- a/run-scheduled.py
+++ b/run-scheduled.py
@@ -11,11 +11,21 @@ from conf.header import HEADER
 from conf import conf
 from habot.birthdays import BirthdayReminder
 from habot.bot import (handle_PMs, SendWinnerMessage, AwardWinner,
-                       CreateNextSharingWeekend)
+                       CreateNextSharingWeekend, UpdatePartyDescription)
 from habot.exceptions import CommunicationFailedException
 from habot.io import HabiticaMessager
 from habot.habitica_operations import HabiticaOperator
 from habot.logger import get_logger
+
+
+def update_party_description():
+    """
+    Update the quest queue in the party description to match the wiki page.
+
+    This is done silently: if everything works as intended, nobody is notified.
+    """
+    result = UpdatePartyDescription().act("update-party-description")
+    get_logger().info(result)
 
 
 def bday():
@@ -127,6 +137,7 @@ if __name__ == "__main__":
     schedule.every(1).minutes.do(fetch_messages)
     schedule.every(1).minutes.do(handle_PMs)
     schedule.every(4).hours.do(join_quest)
+    schedule.every(6).hours.do(update_party_description)
 
     schedule.every().tuesday.at("18:00").do(sharing_winner_message)
     schedule.every().tuesday.at("18:10").do(handle_sharing_weekend)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,18 +20,23 @@ from tests.data.test_tasks import TEST_TASKS
 
 @pytest.fixture(autouse=True)
 @surrogate("conf.secrets.habitica_credentials")
-def set_test_credentials():
+def test_credentials():
     """
     Set the configuration values of PLAYER_USER_ID and PLAYER_API_TOKEN.
+
+    Returns them as a dict for use in other tests.
 
     This is done using different patching mechanic (surrogate + unittest.mock
     instead of monkeypatch) than most other mocking/patching due to this being
     required in order to patch a possibly non-existent module.
     """
+    credentials = {"PLAYER_USER_ID": "totally-not-a-real-user-id",
+                   "PLAYER_API_TOKEN": "totally-not-a-real-apikey"}
     unittest.mock.patch("conf.secrets.habitica_credentials",
-                        "PLAYER_USER_ID", "not-a-real-user-id")
+                        "PLAYER_USER_ID", credentials["PLAYER_USER_ID"])
     unittest.mock.patch("conf.secrets.habitica_credentials",
-                        "PLAYER_API_TOKEN", "not-a-real-token")
+                        "PLAYER_API_TOKEN", credentials["PLAYER_API_TOKEN"])
+    return credentials
 
 
 @pytest.fixture(autouse=True)
@@ -99,15 +104,15 @@ def mock_task_finding(requests_mock):
 
 
 @pytest.fixture()
-def header_fx():
+def header_fx(test_credentials):
     """
     Return a header dict for testing.
     """
     return {
         "x-client":
             "f687a6c7-860a-4c7c-8a07-9d0dcbb7c831-habot_testing",
-        "x-api-user": "totally-not-a-real-userid",
-        "x-api-key":  "totally-not-a-real-apikey",
+        "x-api-user": test_credentials["PLAYER_USER_ID"],
+        "x-api-key": test_credentials["PLAYER_API_TOKEN"],
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,11 @@ Shared test stuff
 
 import datetime
 import re
+import unittest.mock
+
 import mysql.connector
 import pytest
+from surrogate import surrogate
 import testing.mysqld
 
 from habot.db import DBOperator
@@ -13,6 +16,22 @@ from tests.data.test_tasks import TEST_TASKS
 
 # pylint doesn't handle fixtures well
 # pylint: disable=redefined-outer-name
+
+
+@pytest.fixture(autouse=True)
+@surrogate("conf.secrets.habitica_credentials")
+def set_test_credentials():
+    """
+    Set the configuration values of PLAYER_USER_ID and PLAYER_API_TOKEN.
+
+    This is done using different patching mechanic (surrogate + unittest.mock
+    instead of monkeypatch) than most other mocking/patching due to this being
+    required in order to patch a possibly non-existent module.
+    """
+    unittest.mock.patch("conf.secrets.habitica_credentials",
+                        "PLAYER_USER_ID", "not-a-real-user-id")
+    unittest.mock.patch("conf.secrets.habitica_credentials",
+                        "PLAYER_API_TOKEN", "not-a-real-token")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/data/party-wikipage.html
+++ b/tests/data/party-wikipage.html
@@ -1,0 +1,3462 @@
+<!DOCTYPE html>
+<html><body>
+<p>b'
+
+</p>
+<meta charset="UTF-8">
+<title>The Keep:Mental Health Warriors Unite | Habitica Wiki | Fandom</title>
+<script>document.documentElement.className = document.documentElement.className.replace( /(^|\\s)client-nojs(\\s|$)/, "$1client-js$2" );</script>
+<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgCanonicalNamespace":"The_Keep","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":112,"wgPageName":"The_Keep:Mental_Health_Warriors_Unite","wgTitle":"Mental Health Warriors Unite","wgCurRevisionId":159309,"wgRevisionId":159309,"wgArticleId":54892,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["The Armory","Parties"],"wgBreakFrames":false,"wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgMonthNamesShort":["","Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"wgRelevantPageName":"The_Keep:Mental_Health_Warriors_Unite","wgRelevantArticleId":54892,"wgRequestId":"7d91fedcc5f8019","wgCSPNonce":false,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgNoExternals":false,"wgArticleInterlangList":[],"wikiaPageType":"extra","wgVisualEditor":{"pageLanguageCode":"en","pageLanguageDir":"ltr","pageVariantFallbacks":"en","usePageImages":false,"usePageDescriptions":false},"wgIsTestModeEnabled":false,"wgEnableLightboxExt":true,"wgMFDisplayWikibaseDescriptions":{"search":false,"nearby":false,"watchlist":false,"tagline":false},"egMapsScriptPath":"/extensions/Maps/","egMapsDebugJS":false,"egMapsAvailableServices":["leaflet","googlemaps3"],"egMapsLeafletLayersApiKeys":{"MapBox":"","MapQuestOpen":"","Thunderforest":"","GeoportailFrance":""},"wgVisualEditorToolbarScrollOffset":0,"wgVisualEditorUnsupportedEditParams":["undo","undoafter","veswitched"],"wgEditSubmitButtonLabelPublish":false,"wgCodeMirrorEnabled":true,"egFacebookAppId":"112328095453510","comscoreKeyword":"wikiacsid_games","quantcastLabels":"Genre.casual,Genre.free2play,Genre.rpg,Genre.sim,Media.games,Theme.psychological,Theme.sliceoflife","wgCategorySelect":{"defaultNamespace":"Category","defaultNamespaces":"Category"},"wgEnableDiscussions":false,"viewTrackUrlPrefix":"https://beacon.wikia-services.com/__track/view?c=751324\\u0026lc=en\\u0026lid=75\\u0026x=habitrpg\\u0026s=oasis\\u0026mobile_theme=fandom-light\\u0026rollout_tracking=ucp","wgEnableHydraFeatures":false,"wgEnableWikiaBarExt":true,"wgEnableWikiaBarAds":true,"wgWikiaBarMainLanguages":["de","en","es","fr"],"wgPageLanguageHasWordBreaks":true,"personalizedRecommendationsMessage":"Recommended for you","wgBlankImgUrl":"data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D","wgPerformanceMonitoringSamplingFactor":10,"wgPerformanceMonitoringEndpointUrl":"https://beacon.wikia-services.com/__track/special/performance_metrics?w=751324\\u0026lc=en\\u0026d=habitrpg\\u0026s=oasis\\u0026u=0\\u0026i=sjc-prod\\u0026a=https%3A%2F%2Fhabitica.fandom.com%2Fwiki%2FThe_Keep%3AMental_Health_Warriors_Unite","wgSoftwareVersion":"release-189.004@release-189.004\
+","wgRailModuleList":["Fandom\\\\Oasis\\\\Rail\\\\Modules\\\\RecentActivityModuleService","Fandom\\\\Oasis\\\\Rail\\\\Modules\\\\PopularPagesModuleService"]});mw.loader.state({"site.styles":"ready","noscript":"ready","user.styles":"ready","site":"ready","user.options":"ready","user.tokens":"loading","ext.portableInfobox.css":"ready","ext.fandomVideo.css":"ready","mediawiki.legacy.shared":"ready","mediawiki.legacy.commonPrint":"ready","mediawiki.toc.styles":"ready","ext.visualEditor.desktopArticleTarget.noscript":"ready","ext.staffSig.css":"ready","ext.fandom.bannerNotifications.css":"ready","ext.fandom.DesignSystem.css":"ready","vendor.bootstrap.popover.css":"ready","ext.fandom.wikiaBar.css":"ready","ext.fandom.UserPreferencesV2.css":"ready","ext.fandom.CreatePage.css":"ready","ext.fandom.Thumbnails.css":"ready","skin.oasis.fanFeed.css":"ready","skin.oasis.pageheader.Share.css":"ready","ext.fandom.ArticleInterlang.css":"ready","ext.fandom.coreRuntimeStyles":"ready","skin.oasis.css":"ready","skin.oasis.rail.activityModule.css":"ready","skin.oasis.rail.popularPages.css":"ready","skin.oasis.rail-layout.css":"ready"});mw.loader.implement("user.tokens@0tffind",function($,jQuery,require,module){/*@nomin*/mw.user.tokens.set({"editToken":"+\\\\","patrolToken":"+\\\\","watchToken":"+\\\\","csrfToken":"+\\\\"});
+});RLPAGEMODULES=["ext.portableInfobox.js","ext.Tabber","mediawiki.page.startup","mediawiki.page.ready","jquery.tablesorter","mediawiki.toc","mediawiki.searchSuggest","ext.visualEditor.desktopArticleTarget.init","ext.visualEditor.targetLoader","ext.fandom.FacebookTags.js","ext.fandom.ae.babTracking.js","ext.fandom.ae.consentQueue.js","ext.fandom.AnalyticsEngine.comscore.js","ext.fandom.AnalyticsEngine.quantcast.js","ext.categorySelect.css","ext.categorySelect.js","ext.fandom.bannerNotifications.js","ext.fandom.DesignSystem.js","ext.fandom.DesignSystem.CommunityHeader.js","ext.fandom.HeartbeatTracking.js","ext.fandom.Track.pageview.js","ext.fandom.wikiaBar.js","ext.fandom.ContentReview.legacyLoaders.js","ext.fandom.ContentReview.jsReload.js","ext.fandom.site","ext.fandom.ImportJs","ext.fandom.ContentReviewTestModeMessages","ext.fandom.SeoRedlinks.anchors.js","ext.fandom.CreatePage.js","ext.fandom.TimeAgoMessaging.js","ext.fandom.VisitSource.js","ext.fandom.Thumbnails.js","skin.oasis.FanFeed.js","skin.oasis.pageheader.Share.js","ext.fandom.WikiaInYourLang.js","ext.fandom.performanceMonitoring.js","oasisMessages","skin.oasis.lazyRail.js","ext.fandom.Lightbox.js"];mw.loader.load(RLPAGEMODULES);});</script>
+<link rel="stylesheet" href="/load.php?lang=en&amp;modules=ext.fandom.ArticleInterlang.css%7Cext.fandom.CreatePage.css%7Cext.fandom.DesignSystem.css%7Cext.fandom.Thumbnails.css%7Cext.fandom.UserPreferencesV2.css%7Cext.fandom.bannerNotifications.css%7Cext.fandom.coreRuntimeStyles%7Cext.fandom.wikiaBar.css%7Cext.fandomVideo.css%7Cext.portableInfobox.css%7Cext.staffSig.css%7Cext.visualEditor.desktopArticleTarget.noscript%7Cmediawiki.legacy.commonPrint%2Cshared%7Cmediawiki.toc.styles%7Cskin.oasis.css%7Cskin.oasis.fanFeed.css%7Cskin.oasis.pageheader.Share.css%7Cskin.oasis.rail-layout.css%7Cskin.oasis.rail.activityModule.css%7Cskin.oasis.rail.popularPages.css%7Cvendor.bootstrap.popover.css&amp;only=styles&amp;skin=oasis">
+<script async="" src="/load.php?cb=20210325004927&amp;lang=en&amp;modules=startup&amp;only=scripts&amp;skin=oasis"></script>
+<link rel="stylesheet" href="https://static.wikia.nocookie.net/fandom-ae-assets/platforms/v81.17.1/ucp/styles.css">
+<meta name="ResourceLoaderDynamicStyles" content="">
+<link rel="stylesheet" href="/load.php?lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=oasis">
+<meta name="generator" content="MediaWiki 1.33.3">
+<meta name="description" content="Welcome to our beautiful Habitica party wiki page! We are the Mental Health Warriors Unite, an active English-speaking party of Habiticians dedicated to mental health. This party is for people who are battling with their mental health, disorder and/or illness(for example, anxiety and depression...">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@getfandom">
+<meta name="twitter:url" content="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite">
+<meta name="twitter:title" content="The Keep:Mental Health Warriors Unite | Habitica Wiki | Fandom">
+<meta name="twitter:description" content="The Keep:Mental Health Warriors Unite | Habitica Wiki | Fandom">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes, minimum-scale=0.25, maximum-scale=5.0">
+<link rel="alternate" type="application/x-wiki" title="Edit" href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit">
+<link rel="edit" title="Edit" href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit">
+<link rel="shortcut icon" href="https://static.wikia.nocookie.net/habitrpg/images/6/64/Favicon.ico/revision/latest?cb=20170614123540">
+<link rel="search" type="application/opensearchdescription+xml" href="/opensearch_desc.php" title="Habitica Wiki (en)">
+<link rel="EditURI" type="application/rsd+xml" href="https://habitica.fandom.com/api.php?action=rsd">
+<link rel="license" href="https://www.fandom.com/licensing">
+<link rel="alternate" type="application/atom+xml" title="Habitica Wiki Atom feed" href="/wiki/Special:RecentChanges?feed=atom">
+<link rel="canonical" href="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite">
+	<meta property="fb:app_id" content="112328095453510" prefix="fb: http://www.facebook.com/2008/fbml">
+
+	<meta property="og:type" content="article">
+
+	<meta property="og:site_name" content="Habitica Wiki">
+
+	<meta property="og:title" content="Mental Health Warriors Unite">
+
+	<meta property="og:url" content="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite">
+
+	<meta property="og:image" content="https://static.wikia.nocookie.net/habitrpg/images/3/37/Scene_party_healing.png/revision/latest?cb=20180702205627">
+
+<script>var ads={"context":{"opts":{"adEngineVersion":"v81.17.1","enableCheshireCat":true,"enableTLBPlaceholder":true,"enableTBPlaceholder":true,"enableICBPlaceholder":true,"pageType":"all_ads","platformName":"oasis","showAds":true},"targeting":{"enablePageCategories":true,"esrbRating":"everyone","hasPortableInfobox":true,"isUcp":true,"mappedVerticalName":"gaming","newWikiCategories":["gaming"],"pageArticleId":54892,"pageIsArticle":true,"pageName":"The_Keep:Mental_Health_Warriors_Unite","pageType":"extra","wikiCustomKeyValues":"esrb=everyone;sex=m;age=18-34;age=18-24;age=25-34;pform=mobile;sex=f;gnre=casual;gnre=free2play;gnre=rpg;gnre=sim;media=games;theme=psychological;theme=sliceoflife","wikiDbName":"habitrpg","wikiId":751324,"wikiIsTop1000":true,"wikiLanguage":"en","wikiVertical":"games"}},"consentQueue":[]};</script>
+<script src="https://static.wikia.nocookie.net/fandom-ae-assets/platforms/v81.17.1/ucp/main.bundle.js" defer></script>
+<!-- Fandom Beacon Tracking -->
+<script>
+    window.RLQ = window.RLQ || [];
+
+    window.RLQ.push(function () {
+        function genUID() {
+            return \'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx\'.replace(/[xy]/g, function (c) {
+                var r = Math.random() * 16 | 0, v = c === \'x\' ? r : (r & 0x3 | 0x8);
+
+                return v.toString(16);
+            });
+        }
+
+        function getCookieValue(cookieName) {
+            var cookieSplit = (\'; \' + document.cookie).split(\'; \' + cookieName + \'=\');
+
+            return cookieSplit.length === 2 ? cookieSplit.pop().split(\';\').shift() : null;
+        }
+
+        var beacon = getCookieValue(\'wikia_beacon_id\');
+        var sessionId = getCookieValue(\'tracking_session_id\');
+        var pvNumber = getCookieValue(\'pv_number\');
+        var pvNumberGlobal = getCookieValue(\'pv_number_global\');
+        var expireDate = new Date(Date.now() + 1000 * 60 * 30);
+        var path = mw.config.get(\'wgScriptPath\') || \'/\';
+
+        mw.config.set({
+            sessionId: sessionId ? sessionId : genUID(),
+            pvNumber: pvNumber ? parseInt(pvNumber, 10) + 1 : 1,
+            pvNumberGlobal: pvNumberGlobal ? parseInt(pvNumberGlobal, 10) + 1 : 1,
+            pvUID: genUID(),
+            beaconId: beacon
+        });
+
+        document.cookie = \'tracking_session_id=\' + mw.config.get(\'sessionId\') + \'; expires=\' + expireDate.toGMTString() +
+                \';domain=\' + mw.config.get(\'wgCookieDomain\') + \'; path=\' + mw.config.get(\'wgCookiePath\') + \';\';
+        document.cookie = \'pv_number=\' + mw.config.get(\'pvNumber\') + \'; expires=\' + expireDate.toGMTString() +
+                \'; path=\' + path + \';\';
+        document.cookie = \'pv_number_global=\' + mw.config.get(\'pvNumberGlobal\') + \'; expires=\' + expireDate.toGMTString() +
+                \';domain=\' + mw.config.get(\'wgCookieDomain\') + \'; path=\' + mw.config.get(\'wgCookiePath\') + \';\';
+
+        window.fandomTrackingCookiesSet = true;
+    });
+</script>
+
+<script>var Wikia = {};</script>
+<!--[if lt IE 9]><script src="/load.php?lang=en&amp;modules=html5shiv&amp;only=scripts&amp;skin=oasis&amp;sync=1"></script><![endif]-->
+
+
+<div class="wds-global-navigation-wrapper">
+	<nav id="globalNavigation" class="wds-global-navigation wds-search-is-always-visible
+				" navigation>
+		<div class="wds-global-navigation__content-bar-left">
+									<a homepage>
+						<svg class="wds-global-navigation__logo-image"><use xlink:href="#wds-company-logo-fandom-white"></use></svg>					</a>
+							<nav class="wds-global-navigation__links">
+						<a href="https://www.fandom.com/topics/games" class="wds-global-navigation__link" data-tracking-label="link.games">
+	Games</a>
+								<a href="https://www.fandom.com/topics/movies" class="wds-global-navigation__link" data-tracking-label="link.movies">
+	Movies</a>
+								<a href="https://www.fandom.com/topics/tv" class="wds-global-navigation__link" data-tracking-label="link.tv">
+	TV</a>
+								<a href="https://www.fandom.com/video" class="wds-global-navigation__link" data-tracking-label="link.video">
+	Video</a>
+								<div class="wds-dropdown wds-global-navigation__link-group wds-has-dark-shadow">
+	<div class="wds-dropdown__toggle wds-global-navigation__dropdown-toggle wds-global-navigation__link">
+		<span>Wikis</span>
+		<svg class="wds-icon wds-icon-tiny wds-dropdown__toggle-chevron"><use xlink:href="#wds-icons-dropdown-tiny"></use></svg>	</div>
+	<div class="wds-dropdown__content wds-global-navigation__dropdown-content">
+		<ul class="wds-list wds-is-linked">
+							<li>
+											<a href="https://www.fandom.com/explore" data-tracking-label="link.explore">
+	Explore Wikis</a>
+									</li>
+							<li>
+											<a href="//community.fandom.com/wiki/Community_Central" data-tracking-label="link.community-central">
+	Community Central</a>
+									</li>
+							<li>
+											<a href="//community.fandom.com/wiki/Special:CreateNewWiki" class="wds-button wds-is-secondary wds-global-navigation__link-button" data-tracking-label="link.start-a-wiki">
+	Start a Wiki</a>
+									</li>
+					</ul>
+	</div>
+</div>
+			</nav>
+		</div>
+		<div class="wds-global-navigation__content-bar-right">
+							<div class="wds-global-navigation__dropdown-controls">
+					<form class="wds-global-navigation__search-container" action="//habitica.fandom.com/wiki/Special:Search">
+	<div class="wds-global-navigation__search">
+		<div class="wds-global-navigation__search-toggle">
+			<svg class="wds-icon wds-icon-small wds-global-navigation__search-toggle-icon"><use xlink:href="#wds-icons-magnifying-glass-small"></use></svg>			<svg class="wds-icon wds-global-navigation__search-toggle-icon"><use xlink:href="#wds-icons-magnifying-glass"></use></svg>			<span class="wds-global-navigation__search-toggle-text">
+				Search			</span>
+		</div>
+
+		<div class="wds-global-navigation__search-input-wrapper">
+			<div class="wds-dropdown  wds-global-navigation__search-scope">
+				<div class="wds-dropdown__toggle push-dropdown-down">
+						<span>
+							This wiki						</span>
+				<svg class="wds-icon wds-icon-tiny wds-dropdown__toggle-chevron">
+					<use xlink:href="#wds-icons-dropdown-tiny"></use>
+				</svg>
+				</div>
+				<div class="wds-is-not-scrollable wds-dropdown__content">
+					<ul class="wds-list wds-is-linked">
+						<li>
+							<a data-value="internal">
+								This wiki							</a>
+						</li>
+						<li>
+							<a data-value="cross-wiki">
+								All wikis							</a>
+						</li>
+					</ul>
+				</div>
+				&#160;|&#160;
+			</div>
+
+			<div class="wds-dropdown wds-global-navigation__suggestions-anchor wds-no-chevron wds-has-dark-shadow">
+				<input>
+				<input class="wds-global-navigation__search-scope" type="hidden" name="scope" value="internal">
+				<input type="hidden" name="navigationSearch" value="true">
+				<button class="wds-button wds-is-text wds-global-navigation__search-close" type="button">
+					<svg class="wds-icon wds-icon-tiny wds-global-navigation__search-close-icon"><use xlink:href="#wds-icons-close-tiny"></use></svg>				</button>
+				<button class="wds-button wds-global-navigation__search-submit">
+					<svg class="wds-icon wds-icon-small wds-global-navigation__search-submit-icon"><use xlink:href="#wds-icons-arrow-small"></use></svg>				</button>
+			</div>
+		</div>
+	</div>
+</form>
+																<div class="wds-dropdown wds-global-navigation__user-menu wds-has-dark-shadow wds-global-navigation__user-anon">
+	<div class="wds-dropdown__toggle">
+		<div class="wds-avatar" title="">
+			<svg class="wds-avatar__image"><use xlink:href="#wds-icons-avatar"></use></svg>	</div>
+		<svg class="wds-icon wds-icon-tiny wds-dropdown__toggle-chevron"><use xlink:href="#wds-icons-dropdown-tiny"></use></svg>	</div>
+	<div class="wds-dropdown__content wds-is-right-aligned">
+		<ul class="wds-list wds-has-lines-between">
+			<li>
+				<a class="wds-button wds-is-full-width" href="https://www.fandom.com/signin?redirect=https%3A%2F%2Fhabitica.fandom.com%2Fwiki%2FThe_Keep%3AMental_Health_Warriors_Unite" rel="nofollow" data-tracking-label="account.sign-in">
+					Sign In				</a>
+			</li>
+			<li>
+				<div>Don't have an account?</div>
+				<a class="wds-button wds-is-full-width wds-is-secondary" href="https://www.fandom.com/register?redirect=https%3A%2F%2Fhabitica.fandom.com%2Fwiki%2FThe_Keep%3AMental_Health_Warriors_Unite" rel="nofollow" data-tracking-label="account.register">
+					Register				</a>
+			</li>
+		</ul>
+	</div>
+</div>
+																<div class="wds-global-navigation__start-a-wiki">
+							<a href="//community.fandom.com/wiki/Special:CreateNewWiki" class="wds-button wds-is-secondary wds-global-navigation__link-button" data-tracking-label="start-a-wiki">
+	Start a Wiki</a>
+						</div>
+									</div>
+					</div>
+	</nav>
+</div>
+<div class="background-image-gradient"></div>
+<div class="WikiaSiteWrapper">
+	<div class="banner-notifications-placeholder">
+		<div class="wds-banner-notification__container">
+	
+</div>
+	</div>
+	<div class="WikiaPage">
+									<header>
+			<div class="wds-community-header__wordmark" data-tracking="wordmark-image">
+			<a accesskey="z" href="//habitica.fandom.com">
+				<img src="https://vignette4.wikia.nocookie.net/habitrpg/images/8/89/Wiki-wordmark.png/revision/latest?cb=20170614042502" width="65" height="65" alt="Habitica Wiki">
+			</a>
+		</div>
+		<div class="wds-community-header__top-container">
+		<div class="wds-community-header__sitename" data-tracking="sitename">
+			<a href="//habitica.fandom.com">Habitica Wiki</a>
+		</div>
+		<div class="wds-community-header__counter" data-tracking="counter">
+			<span class="wds-community-header__counter-value">1,145</span>
+			<span class="wds-community-header__counter-label">Pages</span>
+		</div>
+		<div class="wds-community-header__wiki-buttons wds-button-group">
+							<a class="wds-button wds-is-secondary createpage" href="/wiki/Special:CreatePage" data-tracking="add-new-page" title="Add new page">
+					<svg class="wds-icon wds-icon-small"><use xlink:href="#wds-icons-page-small"></use></svg>											<span>Add new page</span>
+									</a>
+								</div>
+	</div>
+	<nav class="wds-community-header__local-navigation">
+	<ul class="wds-tabs">
+					<li class="wds-tabs__tab">
+									<div class="wds-dropdown">
+						<div class="wds-tabs__tab-label wds-dropdown__toggle">
+							<a href="#">
+								<span>Basic Gameplay</span>
+							</a>
+							<svg class="wds-icon wds-icon-tiny wds-dropdown__toggle-chevron"><use xlink:href="#wds-icons-dropdown-tiny"></use></svg>						</div>
+						<div class="wds-is-not-scrollable wds-dropdown__content">
+							<ul class="wds-list wds-is-linked wds-has-bolded-items">
+																											<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Tasks</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Habits">Habits</a>
+														</li>
+																											<li>
+															<a href="/wiki/Dailies">Dailies</a>
+														</li>
+																											<li>
+															<a href="/wiki/To-Dos">To-Dos</a>
+														</li>
+																											<li>
+															<a href="/wiki/Rewards">Rewards</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Task Setup</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Establishing_Your_Tasks">Establishing Your Tasks</a>
+														</li>
+																											<li>
+															<a href="/wiki/Task_Type_Choice:_Habit,_Daily,_or_To-Do">Task Type Choice</a>
+														</li>
+																											<li>
+															<a href="/wiki/Naming_Your_Tasks">Naming Your Tasks</a>
+														</li>
+																											<li>
+															<a href="/wiki/Gamifying_Your_Lists">Gamifying Your Lists</a>
+														</li>
+																											<li>
+															<a href="/wiki/Tags">Valid change tags</a>
+														</li>
+																											<li>
+															<a href="/wiki/Checklist">Checklist</a>
+														</li>
+																											<li>
+															<a href="/wiki/Task_List_FAQ">Task List FAQ</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Scoring</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Experience_Points">Experience</a>
+														</li>
+																											<li>
+															<a href="/wiki/Health_Points">Health</a>
+														</li>
+																											<li>
+															<a href="/wiki/Gold_Points">Gold</a>
+														</li>
+																											<li>
+															<a href="/wiki/Level">Level</a>
+														</li>
+																											<li>
+															<a href="/wiki/Drops">Drops</a>
+														</li>
+																											<li>
+															<a href="/wiki/Mana_Points">Mana</a>
+														</li>
+																											<li>
+															<a href="/wiki/Task_Value">Task Value</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Tips/Examples</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Loading_Page_Tips">Loading Page Tips</a>
+														</li>
+																											<li>
+															<a href="/wiki/Category:Methodologies">Methodologies</a>
+														</li>
+																											<li>
+															<a href="/wiki/Category:Sample_Lists">Sample Lists</a>
+														</li>
+																											<li>
+															<a href="/wiki/GTD_with_Habitica">GTD with Habitica</a>
+														</li>
+																											<li>
+															<a href="/wiki/Habitica_Planner">Habitica Planner</a>
+														</li>
+																											<li>
+															<a href="/wiki/Routines">Routines</a>
+														</li>
+																											<li>
+															<a href="/wiki/Self-Imposed_Challenges">Self-Imposed Challenges</a>
+														</li>
+																											<li>
+															<a href="/wiki/The_Keep:The_Mage%27s_Tower">Advice from Other Players</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Obstacles</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Burnout">Burnout</a>
+														</li>
+																											<li>
+															<a href="/wiki/Cheating">Cheating</a>
+														</li>
+																											<li>
+															<a href="/wiki/Death_Mechanics">Death</a>
+														</li>
+																											<li>
+															<a href="/wiki/Obstacles">Other Obstacles</a>
+														</li>
+																											<li>
+															<a href="/wiki/Rest_in_the_Inn">Rest in the Inn</a>
+														</li>
+																											<li>
+															<a href="/wiki/Start_Over_Options">Restarting the Game</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-is-sticked-to-parent wds-dropdown-level-2">
+											<a href="#">
+												<span>Platforms</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="https://habitica.com">Website</a>
+														</li>
+																											<li>
+															<a href="/wiki/Mobile_App_for_iOS:_Habitica">iOS App</a>
+														</li>
+																											<li>
+															<a href="/wiki/Mobile_App_for_Android:_Habitica">Android App</a>
+														</li>
+																											<li>
+															<a href="/wiki/Features_Across_Clients">Features Across Clients</a>
+														</li>
+																											<li>
+															<a href="/wiki/Extensions,_Add-Ons,_and_Customizations">Extensions and Add-Ons</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																								</ul>
+						</div>
+					</div>
+							</li>
+					<li class="wds-tabs__tab">
+									<div class="wds-dropdown">
+						<div class="wds-tabs__tab-label wds-dropdown__toggle">
+							<a href="#">
+								<span>Beyond Basics</span>
+							</a>
+							<svg class="wds-icon wds-icon-tiny wds-dropdown__toggle-chevron"><use xlink:href="#wds-icons-dropdown-tiny"></use></svg>						</div>
+						<div class="wds-is-not-scrollable wds-dropdown__content">
+							<ul class="wds-list wds-is-linked wds-has-bolded-items">
+																											<li>
+											<a href="/wiki/Category_Index">
+												Browse Wiki Categories											</a>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Player</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Avatar">Avatar</a>
+														</li>
+																											<li>
+															<a href="/wiki/Avatar_Customizations">Avatar Customizations</a>
+														</li>
+																											<li>
+															<a href="/wiki/Backgrounds">Backgrounds</a>
+														</li>
+																											<li>
+															<a href="/wiki/Character_Attributes">Stats/Character Attributes</a>
+														</li>
+																											<li>
+															<a href="/wiki/Achievements">Achievements</a>
+														</li>
+																											<li>
+															<a href="/wiki/Profile">Profile</a>
+														</li>
+																											<li>
+															<a href="/wiki/Class_System">Class System</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Social</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Private_Messaging">Inbox</a>
+														</li>
+																											<li>
+															<a href="/wiki/Tavern">Tavern</a>
+														</li>
+																											<li>
+															<a href="/wiki/Party">Party</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guilds">Guilds</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guilds_Guide">Guilds Guide</a>
+														</li>
+																											<li>
+															<a href="/wiki/Challenges">Challenges</a>
+														</li>
+																											<li>
+															<a href="/wiki/Group_Plans">Group Plans</a>
+														</li>
+																											<li>
+															<a href="/wiki/The_Keep:The_Armory">Advertise Your Guild or Party</a>
+														</li>
+																											<li>
+															<a href="/wiki/Find_a_Party">Find a Party</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Inventory</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Inventory_Items">Market</a>
+														</li>
+																											<li>
+															<a href="/wiki/Pets">Pets</a>
+														</li>
+																											<li>
+															<a href="/wiki/Mounts">Mounts</a>
+														</li>
+																											<li>
+															<a href="/wiki/Equipment">Equipment</a>
+														</li>
+																											<li>
+															<a href="/wiki/Quests">Quests</a>
+														</li>
+																											<li>
+															<a href="/wiki/Enchanted_Armoire">Enchanted Armoire</a>
+														</li>
+																											<li>
+															<a href="/wiki/Item_Availability">Item Availability</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-is-sticked-to-parent wds-dropdown-level-2">
+											<a href="#">
+												<span>Events</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Grand_Galas">Grand Galas</a>
+														</li>
+																											<li>
+															<a href="/wiki/World_Bosses">World Bosses</a>
+														</li>
+																											<li>
+															<a href="/wiki/Category:World_Events">More World Events</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-is-sticked-to-parent wds-dropdown-level-2">
+											<a href="#">
+												<span>Settings</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Settings">Site Settings</a>
+														</li>
+																											<li>
+															<a href="/wiki/API_Options">API/UserID</a>
+														</li>
+																											<li>
+															<a href="/wiki/Data_Export">Data Export</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																								</ul>
+						</div>
+					</div>
+							</li>
+					<li class="wds-tabs__tab">
+									<div class="wds-dropdown">
+						<div class="wds-tabs__tab-label wds-dropdown__toggle">
+							<a href="#">
+								<span>Contributing</span>
+							</a>
+							<svg class="wds-icon wds-icon-tiny wds-dropdown__toggle-chevron"><use xlink:href="#wds-icons-dropdown-tiny"></use></svg>						</div>
+						<div class="wds-is-not-scrollable wds-dropdown__content">
+							<ul class="wds-list wds-is-linked wds-has-bolded-items">
+																											<li>
+											<a href="/wiki/Contributing_to_Habitica">
+												What\'s Needed (Start Here!)											</a>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Guidance</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Guidance_for_Artisans">Guidance for Artisans</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guidance_for_Blacksmiths">Guidance for Blacksmiths</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guidance_for_Comrades">Guidance for Comrades</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guidance_for_Fletchers:_Android">Guidance for Fletchers: Android</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guidance_for_Fletchers:_iOS">Guidance for Fletchers: iOS</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guidance_for_Linguists">Guidance for Linguists</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guidance_for_Linguistic_Scribes">Guidance for Linguistic Scribes</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guidance_for_Scribes">Guidance for Scribes</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guidance_for_Socialites">Guidance for Socialites</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guidance_for_Storytellers">Guidance for Storytellers</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Wiki</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Rules_for_Editing_this_Wiki">Rules for Editing this Wiki</a>
+														</li>
+																											<li>
+															<a href="/wiki/Guidance_for_Scribes">Guidance for Scribes</a>
+														</li>
+																											<li>
+															<a href="/wiki/Beyond_the_Classic_Editor:Advanced_Wiki_Editing">Advanced Wiki Editing</a>
+														</li>
+																											<li>
+															<a href="https://habitica.com/groups/guild/9a163b28-ebcf-4e52-87de-5c040ed0f8f8">Wizards of the Wiki Guild</a>
+														</li>
+																											<li>
+															<a href="/wiki/Special:Leaderboard">Wiki Leaderboard</a>
+														</li>
+																											<li>
+															<a href="/wiki/The_Keep:The_Knights_Chambers">Apply for Tier</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Recognition</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Contributor_Rewards">Contributor Rewards</a>
+														</li>
+																											<li>
+															<a href="/wiki/Contributor_Titles">Contributor Titles</a>
+														</li>
+																											<li>
+															<a href="/wiki/Hall_of_Heroes">Hall of Heroes</a>
+														</li>
+																											<li>
+															<a href="/wiki/Art_Credits">Art Credits</a>
+														</li>
+																											<li>
+															<a href="/wiki/Script_Credits">Script Credits</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-is-sticked-to-parent wds-dropdown-level-2">
+											<a href="#">
+												<span>Support Habitica</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Subscription">Subscription</a>
+														</li>
+																											<li>
+															<a href="/wiki/Gems">Gems</a>
+														</li>
+																											<li>
+															<a href="/wiki/Group_Plans">Group Plans</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																								</ul>
+						</div>
+					</div>
+							</li>
+					<li class="wds-tabs__tab">
+									<div class="wds-dropdown">
+						<div class="wds-tabs__tab-label wds-dropdown__toggle">
+							<a href="#">
+								<span>Help</span>
+							</a>
+							<svg class="wds-icon wds-icon-tiny wds-dropdown__toggle-chevron"><use xlink:href="#wds-icons-dropdown-tiny"></use></svg>						</div>
+						<div class="wds-is-not-scrollable wds-dropdown__content">
+							<ul class="wds-list wds-is-linked wds-has-bolded-items">
+																											<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Troubleshooting</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="/wiki/Login_Problems">Login Problems</a>
+														</li>
+																											<li>
+															<a href="/wiki/Outage_Instructions">Outage Instructions</a>
+														</li>
+																											<li>
+															<a href="/wiki/Sync_Errors">Sync Errors</a>
+														</li>
+																											<li>
+															<a href="https://habitica.com/groups/guild/a29da26b-37de-4a71-b0c6-48e72a900dac">Report a Bug</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li class="wds-dropdown-level-2">
+											<a href="#">
+												<span>Other References</span>
+												<svg class="wds-icon wds-icon-tiny wds-dropdown-chevron"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>											</a>
+											<div class="wds-is-not-scrollable wds-dropdown-level-2__content">
+												<ul class="wds-list wds-is-linked">
+																											<li>
+															<a href="https://habitica.com/static/faq/">FAQ</a>
+														</li>
+																											<li>
+															<a href="/wiki/FAQ">In-Depth FAQ</a>
+														</li>
+																											<li>
+															<a href="/wiki/Glossary">Glossary</a>
+														</li>
+																											<li>
+															<a href="/wiki/Whats_New">News</a>
+														</li>
+																											<li>
+															<a href="/wiki/Index">Wiki Index</a>
+														</li>
+																											<li>
+															<a href="/wiki/Habitica_Wiki">Wiki Homepage</a>
+														</li>
+																											<li>
+															<a href="https://trello.com/c/odmhIqyW/440-read-first-table-of-contents">Request a Feature</a>
+														</li>
+																											<li>
+															<a href="https://habitica.com/static/community-guidelines">Community Guidelines</a>
+														</li>
+																									</ul>
+											</div>
+										</li>
+																																				<li>
+											<a href="/wiki/Habitica_Wiki_in_Other_Languages">
+												Wiki in Other Languages											</a>
+										</li>
+																								</ul>
+						</div>
+					</div>
+							</li>
+				<li class="wds-tabs__tab">
+			<div class="wds-dropdown">
+				<div class="wds-tabs__tab-label wds-dropdown__toggle">
+					<svg class="wds-icon-tiny wds-icon"><use xlink:href="#wds-icons-book-tiny"></use></svg>					<span>Explore</span>
+					<svg class="wds-icon wds-icon-tiny wds-dropdown__toggle-chevron"><use xlink:href="#wds-icons-dropdown-tiny"></use></svg>				</div>
+				<div class="wds-is-not-scrollable wds-dropdown__content">
+					<ul class="wds-list wds-is-linked wds-has-bolded-items">
+																		<li>
+								<a href="//habitica.fandom.com/wiki/Special:RecentChanges">Recent Changes</a>
+							</li>
+																								<li>
+								<a href="//habitica.fandom.com/wiki/Special:Random">Random page</a>
+							</li>
+																								<li>
+								<a href="//habitica.fandom.com/wiki/Special:Community">Community</a>
+							</li>
+																								<li>
+								<a href="//habitica.fandom.com/wiki/Special:NewFiles?mediatype=VIDEO&amp;wpFormIdentifier=specialnewimages">Videos</a>
+							</li>
+																								<li>
+								<a href="//habitica.fandom.com/wiki/Special:NewFiles">Images</a>
+							</li>
+																</ul>
+				</div>
+			</div>
+		</li>
+					</ul>
+</nav>
+</header>
+						<div class="WikiaPageContentWrapper">
+														<header id="PageHeader" class="page-header">
+		<div class="page-header__main">
+				<div class="page-header__categories">
+		<span class="page-header__categories-in" data-tracking="categories-top-in">in:</span>
+		<div class="page-header__categories-links">
+			<a href="/wiki/Category:The_Armory" data-tracking="categories-top-0">The Armory</a>, <a href="/wiki/Category:Parties" data-tracking="categories-top-1">Parties</a>					</div>
+	</div>
+			<h1 id="firstHeading" class="page-header__title">The Keep:Mental Health Warriors Unite</h1>
+						</div>
+		<div class="page-header__contribution">
+			<div> <!--Empty div to ensure $actionButton is always pushed to bottom of the container-->
+											</div>
+			<div class="page-header__contribution-buttons">
+			<div class="wds-button-group">
+	<a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit" class="wds-button" id="ca-ve-edit" data-tracking="ca-ve-edit">
+		<svg class="wds-icon wds-icon-small"><use xlink:href="#wds-icons-pencil-small"></use></svg>		<span>Edit</span>
+	</a>
+	<div class="wds-dropdown">
+		<div class="wds-button wds-dropdown__toggle">
+			<svg class="wds-icon wds-icon-tiny wds-dropdown__toggle-chevron"><use xlink:href="#wds-icons-dropdown-tiny"></use></svg>		</div>
+		<div class="wds-dropdown__content wds-is-not-scrollable wds-is-right-aligned">
+			<ul class="wds-list wds-is-linked">
+									<li>
+						<a id="ca-edit" href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit" collapsible data-tracking="ca-edit-dropdown">
+							Edit source						</a>
+					</li>
+									<li>
+						<a id="ca-history" href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=history" data-tracking="ca-history-dropdown">
+							History						</a>
+					</li>
+									<li>
+						<a id="ca-talk" href="/wiki/The_Keep_talk:Mental_Health_Warriors_Unite?action=edit&amp;redlink=1" data-tracking="ca-talk-dropdown">
+							Talk (0)						</a>
+					</li>
+							</ul>
+		</div>
+	</div>
+</div>
+				<a class="wds-button wds-is-secondary" href="#" id="ShareEntryPoint">
+							<svg class="wds-icon wds-icon-small"><use xlink:href="#wds-icons-share-small"></use></svg>						<span>Share</span>
+		</a>
+	</div>
+		</div>
+	</header>
+	<hr class="page-header__separator">
+								<div class="article-with-rail">
+					<article id="WikiaMainContent" class="WikiaMainContent">
+						<div id="WikiaMainContentContainer" class="WikiaMainContentContainer">
+														<div id="content" class="WikiaArticle">
+																<div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N6XD44P" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<div class="mw-parser-output">
+<div class="forumheader">
+<b>The Keep:</b> <a href="/wiki/The_Keep:Index" title="The Keep:Index">Index</a> &gt; <a href="/wiki/The_Keep:The_Armory" title="The Keep:The Armory">The Armory</a> &gt; Mental Health Warriors Unite</div>
+<p><br>
+</p>
+<p><br>
+
+<aside role="region" class="portable-infobox pi-background pi-theme-wikia pi-layout-stacked">
+<h2 class="pi-item pi-item-spacing pi-title" data-source="title">Mental Health Warriors Unite</h2>
+
+<figure class="pi-item pi-image" data-source="image">
+	<a href="https://static.wikia.nocookie.net/habitrpg/images/3/37/Scene_party_healing.png/revision/latest?cb=20180702205627" class="image image-thumbnail" title="">
+		<img src="https://static.wikia.nocookie.net/habitrpg/images/3/37/Scene_party_healing.png/revision/latest/scale-to-width-down/350?cb=20180702205627" srcset="https://static.wikia.nocookie.net/habitrpg/images/3/37/Scene_party_healing.png/revision/latest/scale-to-width-down/350?cb=20180702205627 1x, https://static.wikia.nocookie.net/habitrpg/images/3/37/Scene_party_healing.png/revision/latest/scale-to-width-down/700?cb=20180702205627 2x" class="pi-image-thumbnail" alt="" width="270" height="254" data-image-key="Scene_party_healing.png" data-image-name="Scene party healing.png">
+		
+	</a>
+	
+</figure>
+
+<div class="pi-item pi-data pi-item-spacing pi-border-color" data-source="imagecaption">
+	
+	<div class="pi-data-value pi-font"><center>Warriors battling with their mental health.</center></div>
+</div>
+<h2 class="pi-item pi-header pi-secondary-font pi-item-spacing pi-secondary-background">Stats</h2>
+<section class="pi-item pi-group pi-border-color">
+	<table class="pi-horizontal-group">
+	
+	
+	<thead>
+		<tr>
+		
+			<th class="pi-horizontal-group-item pi-data-label pi-secondary-font pi-border-color pi-item-spacing" data-source="primary stat">Primary Stat</th>
+		
+			<th class="pi-horizontal-group-item pi-data-label pi-secondary-font pi-border-color pi-item-spacing" data-source="secondary stat">Secondary Stat</th>
+		
+			<th class="pi-horizontal-group-item pi-data-label pi-secondary-font pi-border-color pi-item-spacing" data-source="difficulty">Difficulty Rating</th>
+		
+		</tr>
+	</thead>
+	
+	<tbody>
+	<tr>
+	
+		<td class="pi-horizontal-group-item pi-data-value pi-font pi-border-color pi-item-spacing" data-source="primary stat">Kindness</td>
+	
+		<td class="pi-horizontal-group-item pi-data-value pi-font pi-border-color pi-item-spacing" data-source="secondary stat">Persistence</td>
+	
+		<td class="pi-horizontal-group-item pi-data-value pi-font pi-border-color pi-item-spacing" data-source="difficulty">
+<div class="center"><div class="floatnone"><a href="https://static.wikia.nocookie.net/habitrpg/images/b/be/Shop_protectAura.png/revision/latest?cb=20160414014927" class="image"><img alt="Shop protectAura.png" src="https://static.wikia.nocookie.net/habitrpg/images/b/be/Shop_protectAura.png/revision/latest/scale-to-width-down/40?cb=20160414014927" decoding="async" width="40" height="40" data-image-name="Shop protectAura.png" data-image-key="Shop_protectAura.png"></a></div></div> 26 warriors</td>
+	
+	</tr>
+	</tbody>
+</table>
+
+</section>
+<h2 class="pi-item pi-header pi-secondary-font pi-item-spacing pi-secondary-background">Considerations</h2>
+
+<div class="pi-item pi-data pi-item-spacing pi-border-color" data-source="strengths">
+	
+		<h3 class="pi-data-label pi-secondary-font">Strength</h3>
+	
+	<div class="pi-data-value pi-font">Safe place, positive force for hope</div>
+</div>
+
+<div class="pi-item pi-data pi-item-spacing pi-border-color" data-source="weaknesses">
+	
+		<h3 class="pi-data-label pi-secondary-font">Weakness</h3>
+	
+	<div class="pi-data-value pi-font">Chat can contain triggering topics</div>
+</div>
+</aside>
+
+Welcome to our beautiful Habitica party wiki page! We are the Mental Health Warriors Unite, an active English-speaking <a href="/wiki/Party" title="Party">party</a> of Habiticians dedicated to mental health. This party is for people who are battling with their mental health, disorder and/or illness&#160;(for example, <a href="/wiki/Adapting_Habitica_for_Anxiety_and_Depression" title="Adapting Habitica for Anxiety and Depression">anxiety and depression</a>, schizophrenia, eating disorders, etc.) and seek a supportive and understanding group of people. In the Mental Health Warriors Unite, they can build a place that is real and close enough to be open about the struggles and challenges they are facing while remaining to be a positive force for hope.
+</p>
+<p><b>"If you change I to we, Illness becomes wellness."</b>
+</p>
+<div id="toc" class="toc">
+<input type="checkbox" role="button" id="toctogglecheckbox" class="toctogglecheckbox" style="display:none"><div class="toctitle" lang="en" dir="ltr">
+<h2>Contents</h2>
+<span class="toctogglespan"><label class="toctogglelabel" for="toctogglecheckbox"></label></span>
+</div>
+<ul>
+<li class="toclevel-1">
+<a href="#Introduction"><span class="tocnumber">1</span> <span class="toctext">Introduction</span></a>
+<ul>
+<li class="toclevel-2"><a href="#Party_Rules"><span class="tocnumber">1.1</span> <span class="toctext">Party Rules</span></a></li>
+<li class="toclevel-2"><a href="#History"><span class="tocnumber">1.2</span> <span class="toctext">History</span></a></li>
+<li class="toclevel-2 tocsection-1"><a href="#Achievements"><span class="tocnumber">1.3</span> <span class="toctext">Achievements</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1">
+<a href="#Members"><span class="tocnumber">2</span> <span class="toctext">Members</span></a>
+<ul>
+<li class="toclevel-2"><a href="#How_to_Become_a_Member"><span class="tocnumber">2.1</span> <span class="toctext">How to Become a Member</span></a></li>
+<li class="toclevel-2 tocsection-2"><a href="#Current_Members"><span class="tocnumber">2.2</span> <span class="toctext">Current Members</span></a></li>
+<li class="toclevel-2 tocsection-3"><a href="#Gem_Sponsors"><span class="tocnumber">2.3</span> <span class="toctext">Gem Sponsors</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-4">
+<a href="#Quests_.26_the_Quest_Queue"><span class="tocnumber">3</span> <span class="toctext">Quests &amp; the Quest Queue</span></a>
+<ul>
+<li class="toclevel-2"><a href="#How_It_Works"><span class="tocnumber">3.1</span> <span class="toctext">How It Works</span></a></li>
+<li class="toclevel-2"><a href="#The_Quest_Queue_.28current_as_of_04.2F19.2F2021.29:"><span class="tocnumber">3.2</span> <span class="toctext">The&#160;Quest Queue&#160;(current as of 04/19/2021):</span></a></li>
+<li class="toclevel-2 tocsection-5"><a href="#Available_Quests_.26_Voting"><span class="tocnumber">3.3</span> <span class="toctext">Available Quests &amp; Voting</span></a></li>
+<li class="toclevel-2 tocsection-6"><a href="#Completed_Quests"><span class="tocnumber">3.4</span> <span class="toctext">Completed Quests</span></a></li>
+<li class="toclevel-2">
+<a href="#Quest_Resources"><span class="tocnumber">3.5</span> <span class="toctext">Quest Resources</span></a>
+<ul>
+<li class="toclevel-3"><a href="#Auto_Accept_Quest_Instructions"><span class="tocnumber">3.5.1</span> <span class="toctext">Auto Accept Quest Instructions</span></a></li>
+<li class="toclevel-3"><a href="#Damage_Calculator"><span class="tocnumber">3.5.2</span> <span class="toctext">Damage Calculator</span></a></li>
+<li class="toclevel-3"><a href="#Damage_Tables"><span class="tocnumber">3.5.3</span> <span class="toctext">Damage Tables</span></a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li class="toclevel-1">
+<a href="#Participating_in_Party_Chat"><span class="tocnumber">4</span> <span class="toctext">Participating in Party Chat</span></a>
+<ul>
+<li class="toclevel-2"><a href="#The_goals_of_this_section:"><span class="tocnumber">4.1</span> <span class="toctext">The goals of this section:</span></a></li>
+<li class="toclevel-2"><a href="#The_3_main_ways_we_participate_in_chat_.28outside_of_challenges.29:"><span class="tocnumber">4.2</span> <span class="toctext">The 3 main ways we participate in chat (outside of challenges):</span></a></li>
+<li class="toclevel-2"><a href="#Notes.2C_tips.2C_guidelines"><span class="tocnumber">4.3</span> <span class="toctext">Notes, tips, guidelines</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1">
+<a href="#Party_Challenges"><span class="tocnumber">5</span> <span class="toctext">Party Challenges</span></a>
+<ul>
+<li class="toclevel-2 tocsection-7"><a href="#Current_Party_Challenges"><span class="tocnumber">5.1</span> <span class="toctext">Current Party Challenges</span></a></li>
+<li class="toclevel-2"><a href="#Old_Party_Challenges"><span class="tocnumber">5.2</span> <span class="toctext">Old Party Challenges</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-8">
+<a href="#Misc._Habitica_Resources"><span class="tocnumber">6</span> <span class="toctext">Misc. Habitica Resources</span></a>
+<ul>
+<li class="toclevel-2"><a href="#Avatar_Preview_Tool"><span class="tocnumber">6.1</span> <span class="toctext">Avatar Preview Tool</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-9">
+<a href="#Recommended_Guilds_.26_Guild_Challenges"><span class="tocnumber">7</span> <span class="toctext">Recommended Guilds &amp; Guild Challenges</span></a>
+<ul>
+<li class="toclevel-2 tocsection-10"><a href="#Other_Recommended_Challenges"><span class="tocnumber">7.1</span> <span class="toctext">Other Recommended Challenges</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-11"><a href="#In_case_of_emergency..."><span class="tocnumber">8</span> <span class="toctext">In case of emergency...</span></a></li>
+<li class="toclevel-1 tocsection-12">
+<a href="#Mental_Health_Resources"><span class="tocnumber">9</span> <span class="toctext">Mental Health Resources</span></a>
+<ul>
+<li class="toclevel-2 tocsection-13"><a href="#Subsection_1:_Youtube_Videos"><span class="tocnumber">9.1</span> <span class="toctext">Subsection 1: Youtube Videos</span></a></li>
+<li class="toclevel-2 tocsection-14"><a href="#Subsection_2:_Inspirational_Image_Gallery"><span class="tocnumber">9.2</span> <span class="toctext">Subsection 2: Inspirational Image Gallery</span></a></li>
+<li class="toclevel-2 tocsection-15"><a href="#Subsection_3:_Links"><span class="tocnumber">9.3</span> <span class="toctext">Subsection 3: Links</span></a></li>
+<li class="toclevel-2 tocsection-16"><a href="#Subsection_4:_Stay_home.2C_Stay_busy"><span class="tocnumber">9.4</span> <span class="toctext">Subsection 4: Stay home, Stay busy</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-17"><a href="#MORE.3F"><span class="tocnumber">10</span> <span class="toctext">MORE?</span></a></li>
+</ul>
+</div>
+
+<h2><span class="mw-headline" id="Introduction">Introduction</span></h2>
+<h3><span class="mw-headline" id="Party_Rules">Party Rules</span></h3>
+<p>Next, to the <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/static/community-guidelines">Habitca Community Guidelines</a>, the Mental Health Warriors Unite also has some rules to keep it a safe space for every party member. The party rules are as follows:
+</p>
+<ul>
+<li>Be respectful.</li>
+<li>Do not start a quest unless it is up next in the <a href="/wiki/The_Keep:Mental_Health_Warriors_Unite#Quests_.26_the_Quest_Queue" title="The Keep:Mental Health Warriors Unite">Quest Queue section</a>.</li>
+<li>If you need to take a break from Habitica, let the <a href="/wiki/Party#Party_Leader" title="Party">party leader</a> know via <a href="/wiki/Private_Messaging" title="Private Messaging">private message</a>. Members who have been <u>inactive for three months (or more)</u> without an explanation may be removed from the party. If they return to Habitica, they will still be welcome to come back to the party if there is room.</li>
+</ul>
+<ul><li>Due to the nature of this party, chat will unavoidably contain some triggering topics. We don\'t want anyone to feel censored and we want to <b>encourage</b> people to discuss their thoughts and feelings as openly as possible, including feelings of suicidality. Use of trigger warnings is encouraged, but as of 04-02-2021 the party agreed that some statements are too potentially upsetting for any trigger warning to cover. Thus, the following things should NOT be shared in chat:
+<ol>
+<li>"Suicide Announcements" (it is ok to say that you are feeling suicidal, but not ok to state specific intentions or post "goodbye world"-type messages)</li>
+<li>Use of specific numbers when discussing eating disorder issues</li>
+<li>Use of hate speech such as racial slurs or blaspheming</li>
+</ol>
+<ul><li>For further guidelines regarding party chat, please see <a target="_blank" rel="noreferrer noopener" class="external text" href="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite#Participating_in_Party_Chat">the "Participating in Party Chat" section of this page</a>. If you still have any questions about speech policies, please refer to <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/profile/43bb8e69-8d1c-4752-ae6a-65d58255153d">@JenieB</a>.</li></ul>
+</li></ul>
+<ul>
+<li>If you are participating in a boss quest and have missed some dailies, please consider spending the night in the <a href="/wiki/Inn" class="mw-redirect" title="Inn">Inn</a> to <a href="/wiki/Rest_in_the_Inn#Resting_in_the_Inn_while_on_a_Quest" title="Rest in the Inn">avoid harming your party members</a>.<u>A single person can kill the entire party if they have missed enough dailies.</u> Some bosses do more damage than others, and it is reasonable that a high-level boss could deal over 50 HP damage at once when a single member missed their dailies.</li>
+<li>And of course, try to have fun and show off your <a href="/wiki/Equipment#Costumes" title="Equipment">costumes</a> and the pets and mounts you\'ve raised!</li>
+<li>All rules (and other policies, such as the wait-period between issuing a quest invitation and the start of the quest, the potential need for trigger warnings regarding certain topics, etc.) can be re-visted and re-voted upon as membership changes. We strive to meet the needs of our current members as democratically as possible and to make the party a safe and welcoming space for all our members.</li>
+</ul>
+<h3><span class="mw-headline" id="History">History</span></h3>
+<p>It was the <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://www.wincalendar.com/Calendar/Date/January-22-2019">33rd day</a> into Earth\'s winter of 2019 when, on January 22nd, the party received the name <i>Mental Health Warriors Unite</i>. Just like the <a href="/wiki/Habitica_Naming_Day" title="Habitica Naming Day">Habitica Naming Day</a>, the brave warriors celebrate the <i>Party Naming Day</i> with a lot of joy and cake.
+</p>
+<h3>
+<span class="mw-headline" id="Achievements">Achievements</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=1" class="mw-editsection-visualeditor" title="Edit section: Achievements">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=1" title="Edit section: Achievements"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<p class="mw-empty-elt"></p>
+<figure class="thumb tright show-info-icon" style="width: 182px"> 	<a href="https://static.wikia.nocookie.net/habitrpg/images/3/39/Scene_achievement.png/revision/latest?cb=20190303224044" class="image"><img alt="Scene achievement.png" src="https://static.wikia.nocookie.net/habitrpg/images/3/39/Scene_achievement.png/revision/latest/scale-to-width-down/180?cb=20190303224044" decoding="async" width="180" height="112" class="thumbimage" data-image-name="Scene achievement.png" data-image-key="Scene_achievement.png"></a> 	 	<figcaption class="thumbcaption"> 		 			<a href="/wiki/File:Scene_achievement.png" class="info-icon"><svg><use xlink:href="#wds-icons-info-small"></use></svg></a> 		 		 		 	</figcaption> </figure><p> Celebrate the wins of the party! The warriors have come so far since the start of the party that they decided that a little success can\'t hurt anybody. So be sure to check the table below for the party achievements. You may not see them physically in Habitica, but that doesn\'t mean they don\'t exist!
+</p>
+<p class="mw-empty-elt"></p>
+<p>Keep in mind that the achievement icons are <a href="/wiki/Art_Credits#Achievement_Badges" title="Art Credits">borrowed</a> from actual Habitica <a href="/wiki/Achievements" title="Achievements">achievements</a>, but are used for a different purpose here.
+</p>
+<table class="article-table sortable" border="0" cellpadding="1" cellspacing="1" style="width: 650px;">
+
+<tbody>
+<tr>
+<th scope="col">Icon
+</th>
+<th scope="col" style="text-align:left;">Name
+</th>
+<th scope="col" style="text-align:center;">Times Completed
+</th>
+</tr>
+<tr>
+<td style="text-align:center;">
+<div class="floatleft"><a href="https://static.wikia.nocookie.net/habitrpg/images/b/bb/Achievement-cake2x.png/revision/latest?cb=20190314080117" class="image"><img alt="Achievement-cake2x.png" src="https://static.wikia.nocookie.net/habitrpg/images/b/bb/Achievement-cake2x.png/revision/latest/scale-to-width-down/48?cb=20190314080117" decoding="async" width="48" height="52" data-image-name="Achievement-cake2x.png" data-image-key="Achievement-cake2x.png"></a></div>
+</td>
+<td>
+<a href="/wiki/The_Keep:Mental_Health_Warriors_Unite#Party_Naming_Day" title="The Keep:Mental Health Warriors Unite">Party Naming Day</a>
+</td>
+<td style="text-align:center;">1
+</td>
+</tr>
+<tr>
+<td style="text-align:center;">
+<div class="floatleft"><a href="https://static.wikia.nocookie.net/habitrpg/images/b/b4/Achievement-wolf2x.png/revision/latest?cb=20190314081253" class="image" title="Started a Pet Quest"><img alt="Started a Pet Quest" src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" decoding="async" width="48" height="52" data-image-name="Achievement-wolf2x.png" data-image-key="Achievement-wolf2x.png" data-src="https://static.wikia.nocookie.net/habitrpg/images/b/b4/Achievement-wolf2x.png/revision/latest/scale-to-width-down/48?cb=20190314081253" class="lazyload"></a></div>
+</td>
+<td>Battle all <a href="/wiki/Quests#Pet_Quests_2" title="Quests">Pet Quests</a>
+</td>
+<td style="text-align:center;">7
+</td>
+</tr>
+</tbody>
+</table>
+<h2><span class="mw-headline" id="Members">Members</span></h2>
+<h3><span class="mw-headline" id="How_to_Become_a_Member">How to Become a Member</span></h3>
+<p class="mw-empty-elt"></p>
+<figure class="thumb tright show-info-icon" style="width: 182px"> 	<a href="https://static.wikia.nocookie.net/habitrpg/images/7/7c/Scene_hat_guild.png/revision/latest?cb=20190118222257" class="image"><img alt="Scene hat guild.png" src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" decoding="async" width="180" height="136" class="thumbimage lazyload" data-image-name="Scene hat guild.png" data-image-key="Scene_hat_guild.png" data-src="https://static.wikia.nocookie.net/habitrpg/images/7/7c/Scene_hat_guild.png/revision/latest/scale-to-width-down/180?cb=20190118222257"></a> 	<noscript><a href="https://static.wikia.nocookie.net/habitrpg/images/7/7c/Scene_hat_guild.png/revision/latest?cb=20190118222257" class="image"><img alt="Scene hat guild.png" src="https://static.wikia.nocookie.net/habitrpg/images/7/7c/Scene_hat_guild.png/revision/latest/scale-to-width-down/180?cb=20190118222257" decoding="async" width="180" height="136" class="thumbimage" data-image-name="Scene hat guild.png" data-image-key="Scene_hat_guild.png" data-src="https://static.wikia.nocookie.net/habitrpg/images/7/7c/Scene_hat_guild.png/revision/latest/scale-to-width-down/180?cb=20190118222257"></a></noscript> 	<figcaption class="thumbcaption"> 		 			<a href="/wiki/File:Scene_hat_guild.png" class="info-icon"><svg><use xlink:href="#wds-icons-info-small"></use></svg></a> 		 		 		 	</figcaption> </figure><p>Many people have seen this beautiful&#160;wiki page and have been interested in joining the Mental Health Warriors Unite&#160;party. If <u>you are a Habitica user struggling with mental illness</u>&#160;and think that our party could help you, contact us.
+</p>
+<p class="mw-empty-elt"></p>
+<p>Your contact person is asl (@x4ojM). To get in touch,&#160;visit their Habitica profile <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/profile/2ab6ff6e-0e5b-4c58-b38f-842afc63c0e5">here</a> and use the envelope icon in the top right corner to send a PM. <b>Do not try to contact them&#160;via this Habitica wiki!</b>
+</p>
+<p>We are a big party and do not always have openings, but we try to accommodate as many people as we can.
+</p>
+<h3>
+<span class="mw-headline" id="Current_Members">Current Members</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=2" class="mw-editsection-visualeditor" title="Edit section: Current Members">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=2" title="Edit section: Current Members"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<p>For the new members of the party; <a target="_blank" rel="noreferrer noopener" class="external text" href="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=2">please add yourself</a> to the table by clicking on the edit button right from the Member header. The place to tell us more about yourself, in a space that is private, is through the <i>Private Profiles</i> link which you can find in the <i>Description</i> section on our Habitica party page.
+</p>
+<table class="article-table" border="1" align="left" cellspacing="1" cellpadding="1" style="width=100%">
+<tbody>
+<tr>
+<th scope="col">Username
+</th>
+<th scope="col">Display name
+</th>
+<th scope="col">Preferred Pronouns
+</th>
+<th scope="col">
+<p>Tell us a little about yourself&#160; (Tell us more about&#160;yourself in a&#160;<a target="_blank" rel="noreferrer noopener" class="external text" href="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite#Current_Challenges">Private Profile</a> )
+</p>
+</th>
+</tr>
+<tr>
+<td>@x4ojM
+</td>
+<td>asl
+</td>
+<td>
+<p>she/her or they/them
+</p>
+</td>
+<td>Ecclectic AND eccentric person, lover of hamsters (owner of a hamster and a rabbit), lover of books, degrees in Mathematics &amp; Visual Arts, living in Midwestern America, surrounded by cornfields.
+</td>
+</tr>
+<tr>
+<td>@JenieB
+</td>
+<td>Jen
+</td>
+<td>she/her
+</td>
+<td>
+<p>grew up in New York, USA&#160; &#160;live in Florida, USA.
+</p>
+<p>Traveled to Canada, Spain, Germany, Qatar, UAE, Saudi Arabia
+</p>
+</td>
+</tr>
+<tr>
+<td>@Carnealation
+</td>
+<td>Neala
+</td>
+<td>any
+</td>
+<td>username is made out of my nickname (Neala) and my favorite flower (carnations)
+</td>
+</tr>
+<tr>
+<td>@snowlorelei
+</td>
+<td>snowlorelei
+</td>
+<td>she/her
+</td>
+<td>I love the ocean and lana del rey. also, yoga, meditation, and "new age" type stuff, writing micropoetry. fave: color: mint, animal: owl, time: twilight, books: yes
+</td>
+</tr>
+<tr>
+<td>@MeIsLoulou
+</td>
+<td>Me is Loulou
+</td>
+<td>she/her or they/them
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>@sanicks
+</td>
+<td>Sanicks
+</td>
+<td>she/her
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>@Corgi_Potato
+</td>
+<td>Corgi Potato
+</td>
+<td>she/her
+</td>
+<td>My name is Britt. I have several mental and physical health diagnoses. I love corgis!
+</td>
+</tr>
+<tr>
+<td>@BlackbirdScraps
+</td>
+<td>Blackbird Scraps
+</td>
+<td>she/her
+</td>
+<td>
+<p>I have a long list of chronic physical &amp; mental health Dx\'s, as well as cognitive ("Pre-Dementia" VERY early onset at 41)&#160;
+My faith in God is my biggest comfort, as well as my family. Fun fact: I have given birth to 6 children over 3 decades,currentlly aged 4-23&#160;and I love them,my husband/also my caregiver, my parents are just amazing. I love papercrafting, sparkly purple things, dogs &amp;&#160;making lists. Midwest USA.
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/profile/defcca82-e783-4371-a1ee-6ed0774d06d0">@hello-titania</a>
+</td>
+<td>tit\xc4\x81nia
+</td>
+<td>she/her
+</td>
+<td>A little fairy queen on an adventure in Habitica.
+</td>
+</tr>
+<tr>
+<td>@perfectnightmare
+</td>
+<td>PerfectNightmare
+</td>
+<td>she/her
+</td>
+<td>Hi, I\'m Lauren. Based in Scotland and have complex physical/mental health issues. Eternal goth and nintendo kid, with a giant sidekick of a dog called Biggie
+</td>
+</tr>
+<tr>
+<td>@Midnight_Reverie
+</td>
+<td>Midnight Reverie
+</td>
+<td>she/her
+</td>
+<td>Mental health and self-care advocate. Peer support worker. In another life I worked in fashion and theatre costuming but life likes to throw curveballs and change happens. Canadian. Board games, video games, animals, and being in nature are rad. My partner and I have a black cat named Mystique.
+</td>
+</tr>
+<tr>
+<td>@Rachael2Worlds
+</td>
+<td>Rachael2Worlds
+</td>
+<td>she/her
+</td>
+<td>I\'m optimistic, I have bipolar disorder and ADHD and perhaps some other stuff, and I am always trying to level-up my life through spirituality, personal development, learning, etc.
+</td>
+</tr>
+<tr>
+<td>@MusicalRose
+</td>
+<td>Musical Rose
+</td>
+<td>she/her
+</td>
+<td>Mother of kitties, lover of all animals. I love music (singing, playing, listening), geek culture, crochet, and ice cream. I struggle with a Depression Demon and Anxiety Monster, but I\'m taking it day by day.
+</td>
+</tr>
+<tr>
+<td>@colorcrush
+</td>
+<td>li (emoji)
+</td>
+<td>she/her
+</td>
+<td>hi, I\'m li! I\'m a college student, and I have generalized/social anxiety and winter seasonal affective disorder. I also love dogs, cats and birds (especially budgies), bread and baked goods, bright and pastel colors, and the color blue.
+</td>
+</tr>
+<tr>
+<td>@zoomymoth
+</td>
+<td>Oliver
+</td>
+<td>he/him
+</td>
+<td>I love most-all living things (especially dogs, solifuges, &amp; spiders) and despite negative associations with pursuing STEM I love studying math &amp; astrophysics. Austim, ADHD, DID, and being trans make things a bit confusing but I\'m trying to figure it all out.
+</td>
+</tr>
+<tr>
+<td>@FunkyLittleUnicorn
+</td>
+<td>FunkyLittleUnicorn
+</td>
+<td>she/her
+</td>
+<td>Film geek, language lover, and owned by two fluffy rabbits who are too cute to be trouble.
+</td>
+</tr>
+<tr>
+<td>
+<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/profile/5120aa4d-daba-4b61-97a5-b7e9aed53ebc">@erinkidd01</a>
+</td>
+<td>Erin
+</td>
+<td>she/her
+</td>
+<td>I\'m a software engineer. I love playing collection based video games, like Pokemon or Animal Crossing. Pikachu is my favorite character and I have tons of stuffed animals. I\'m on this journey with my mini goldendoodle service dog, Cassie.
+</td>
+</tr>
+<tr>
+<td>@nfar
+</td>
+<td>nfar
+</td>
+<td>she/her
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>@Frija
+</td>
+<td>Frija
+</td>
+<td>she/her
+</td>
+<td>Loves cats, books, letters, postcards, walking, dancing and swimming.
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<p>&#8194;
+</p>
+<h3>
+<span class="mw-headline" id="Gem_Sponsors">Gem Sponsors</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=3" class="mw-editsection-visualeditor" title="Edit section: Gem Sponsors">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=3" title="Edit section: Gem Sponsors"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<p>Not all members have a subscription for Habitica, and it is not needed to be a part of this party. However, sometimes, we&#160;are searching for contributors who want to sponsor a new party challenge or new (pet) quests by donating gems. To make the search sponsors easier, <b><a target="_blank" rel="noreferrer noopener" class="external text" href="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=3">members who wish to be a gem sponsor&#160;can add themselves to the list</a></b>. This way, other members know who they can contact to ask for gem sponsoring without feeling&#160;burdened.
+</p>
+<ul>
+<li>tit\xc4\x81nia</li>
+<li>Blackbird Scraps</li>
+<li>PerfectNightmare</li>
+<li>Frija</li>
+</ul>
+<p>Please keep in mind that it is a violation of the <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/static/community-guidelines">Community Guidelines</a> to ask for a gift of gems. You can ask if a member wants to sponsor your idea, but everyone is still free to refuse.
+</p>
+<p>&#160;
+</p>
+<p>&#160;
+</p>
+<h2>
+<span id="Quests_&amp;_the_Quest_Queue"></span><span class="mw-headline" id="Quests_.26_the_Quest_Queue">Quests &amp; the Quest Queue</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=4" class="mw-editsection-visualeditor" title="Edit section: Quests &amp; the Quest Queue">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=4" title="Edit section: Quests &amp; the Quest Queue"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h2>
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">This is an attempt to democratize the process of deciding which quests our party will go on.&#160;If anyone is dissatisfied with the current arrangement or has ideas about how to improve upon it, please send a PM&#160;to asl/@x4ojM to let me know!</span></p>
+<h3><span class="mw-headline" id="How_It_Works">How It Works</span></h3>
+<p><br>
+</p>
+<ul><li>Party members let me (asl/@x4ojM)&#160;know what quests they own by sending me (asl/@x4ojM) PMs.</li></ul>
+<ul><li>I create a list of quests available to the party and post it on this wiki page (see below).</li></ul>
+<ul><li>People can <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://docs.google.com/document/d/1_KyYmyhRfztAdy6rHgaPPQVX2hBl5hT7SJdZmUNkhgY/edit?usp=sharing">VOTE (click for instructions)</a> &#160;for&#160;the quests in those lists.</li></ul>
+<ul><li>Those votes, combined with feedback gathered from party chat and logistical concerns are used to generate the Quest Queue. The Quest Queue lists&#160;which quests the group has&#160;decided they want to go on next.</li></ul>
+<ul><li>If you are the owner of a quest that is coming up soon in the queue, I (asl/@x4ojM) will send you a PM letting you know a day or two in advance that your quest will be coming up and giving you info on when to start it.</li></ul>
+<p><br>
+</p>
+<h3>
+<span id="The_Quest_Queue_(current_as_of_04/19/2021):"></span><span class="mw-headline" id="The_Quest_Queue_.28current_as_of_04.2F19.2F2021.29:">The&#160;Quest Queue&#160;(current as of <u>04/19/2021</u>):</span>
+</h3>
+<ul>
+<li>(CURRENT) Robot (collection)</li>
+<li>1) Wind-Up Hatching Potions (Boss 1000)</li>
+<li>2) Dolphin (Boss 300)</li>
+<li>3) Seahorse (Boss 300)</li>
+<li>4) Monkey (Boss 400)</li>
+<li>5) Cheetah (Boss 600)</li>
+<li>6) Kangaroo (Boss 700)</li>
+<li>7) Silver Hatching Potions (collection)</li>
+</ul>
+<p><br>
+</p>
+<h3>
+<span id="Available_Quests_&amp;_Voting"></span><span class="mw-headline" id="Available_Quests_.26_Voting">Available Quests &amp; Voting</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=5" class="mw-editsection-visualeditor" title="Edit section: Available Quests &amp; Voting">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=5" title="Edit section: Available Quests &amp; Voting"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://docs.google.com/document/d/1_KyYmyhRfztAdy6rHgaPPQVX2hBl5hT7SJdZmUNkhgY/edit?usp=sharing">Vote for UP TO 3 quests by putting your name (or a shortened version of it) in the box in front of the quests you\'re most interested in.</a>
+</p>
+<pre><i><b>HOW TO VOTE &amp; COMPLETE VOTING RULES ARE <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://docs.google.com/document/d/1_KyYmyhRfztAdy6rHgaPPQVX2hBl5hT7SJdZmUNkhgY/edit?usp=sharing">HERE</a>\'</b></i>
+</pre>
+<p><br>
+</p>
+<p><u>HATCHING POTION QUESTS:</u>
+</p>
+<table border="1" cellspacing="0" cellpadding="1" width="0">
+<tbody>
+<tr>
+<td width="127" valign="top">
+<p><a target="_blank" rel="noreferrer noopener" class="external text" href="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=5">VOTE</a>
+</p>
+</td>
+<td width="304" valign="top">
+<p><u><b>Quest/Reward</b></u>
+</p>
+</td>
+<td width="226" valign="top">
+<p><u><b>Difficulty</b></u>
+</p>
+</td>
+<td width="246" valign="top">
+<p><u><b>Owner</b></u>
+</p>
+</td>
+</tr>
+<tr>
+<td width="127" valign="top">Frija
+</td>
+<td width="304" valign="top">Turquoise Hatching Potions
+</td>
+<td width="226" valign="top">collection
+</td>
+<td width="246" valign="top">@JenieB; @erinkidd01(x3)
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>Ruby Hatching Potions
+</td>
+<td>collection
+</td>
+<td>@x4ojM; @JenieB
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>Black Pearl Hatching Potions
+</td>
+<td>Boss HP=725; Str=1.5
+</td>
+<td>@erinkidd01(x3); @JenieB(x2)
+</td>
+</tr>
+<tr>
+<td>IN QUEUE
+</td>
+<td>Fluorite Hatching Potions
+</td>
+<td>Boss HP=1200; Str=2
+</td>
+<td>@erinkidd01; @JenieB
+</td>
+</tr>
+<tr>
+<td>unicorn
+</td>
+<td>Amber Hatching Potions
+</td>
+<td>Boss HP=300; Str=1.5
+</td>
+<td>@erinkidd01; @JenieB
+</td>
+</tr>
+<tr>
+<td>IN QUEUE
+</td>
+<td>Silver Hatching Potions
+</td>
+<td>collection
+</td>
+<td>@erinkidd01(x2); @JenieB
+</td>
+</tr>
+<tr>
+<td>IN QUEUE
+</td>
+<td>Wind-Up Hatching Potions
+</td>
+<td>Boss HP=1000; Str=1
+</td>
+<td>@erinkidd01
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>Confection Hatching Potions
+</td>
+<td>Boss HP=500; Str=2
+</td>
+<td>@colorcrush, @Midnight_Reverie(x4)
+</td>
+</tr>
+</tbody>
+</table>
+<p><br>
+<u>PET QUESTS:</u>
+</p>
+<p>(REWARDS FOR PET QUESTS ARE ALWAYS 3 EGGS OF THAT PET, PLUS VARIABLE AMOUNTS OF XP POINTS AND GOLD BASED ON THE DIFFICULTY OF THE QUEST)
+</p>
+<table border="1" cellspacing="0" cellpadding="1" width="0">
+<tbody>
+<tr>
+<td width="127" valign="top">
+<p><a target="_blank" rel="noreferrer noopener" class="external text" href="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=5">VOTE</a>
+</p>
+</td>
+<td width="314" valign="top">
+<p><u><b>Pet</b></u>
+</p>
+</td>
+<td width="226" valign="top">
+<p><u><b>Difficulty</b></u>
+</p>
+</td>
+<td width="236" valign="top">
+<p><u><b>Owner</b></u>
+</p>
+</td>
+</tr>
+<tr>
+<td width="127" valign="middle">Erin
+</td>
+<td width="314" valign="top">Egg Hunt<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">(this special seasonal quest gives you TEN egg-eggs)</span></p>
+</td>
+<td width="226" valign="middle">collection
+</td>
+<td width="236" valign="middle">@erinkidd01; @x4ojM(x4); @Frija
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>polar bear mount (\xe2\x80\x9cTrapper Santa\xe2\x80\x9d)&#160;
+<p>(special seasonal quest: you get 1 polar bear that is already tamed into a mount)&#160;(CANNOT RECEIVE MORE THAN 1)
+</p>
+</td>
+<td>Boss HP=300; Str=1
+</td>
+<td>@colorcrush; @erinkidd01; @Frija
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>polar bear cub ("Find the Cub")
+<p>(special seasonal quest: you get 1 polar bear pet that cannot be turned into a mount)&#160;(CANNOT RECEIVE MORE THAN 1)
+</p>
+</td>
+<td>collection
+</td>
+<td>@FunkyLittleUnicorn; @erinkidd01; @Frija
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>Penguin
+</td>
+<td>Boss HP=400; Str=1.5
+</td>
+<td>@erinkidd01
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>Sea Serpent
+</td>
+<td>Boss HP=1200; Str=2.5
+</td>
+<td>@perfectnightmare; @FunkyLittleUnicorn
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>T-Rex
+</td>
+<td>Boss HP=500; Str=2
+</td>
+<td>@Frija
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>Gryphon
+</td>
+<td>Boss HP=300; Str=1.5
+</td>
+<td>@FunkyLittleUnicorn
+</td>
+</tr>
+<tr>
+<td>IN QUEUE
+</td>
+<td>Monkey
+</td>
+<td>Boss HP=400; Str=1.5
+</td>
+<td>@Frija
+</td>
+</tr>
+<tr>
+<td>IN QUEUE
+</td>
+<td>Cheetah
+</td>
+<td>Boss HP=600; Str=1.5
+</td>
+<td>@Frija
+</td>
+</tr>
+<tr>
+<td>Frija
+</td>
+<td>Ferret
+</td>
+<td>Boss HP=400; Str=1.5
+</td>
+<td>@Frija
+</td>
+</tr>
+<tr>
+<td>Erin
+</td>
+<td>Treeling
+</td>
+<td>Boss HP=600; Str=1.5
+</td>
+<td>@x4ojM
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>Turtle
+</td>
+<td>Boss HP=300; Str=1.5
+</td>
+<td>@Frija
+</td>
+</tr>
+<tr>
+<td>asl
+</td>
+<td>Yarn
+</td>
+<td>Boss HP=500; Str=1.5
+</td>
+<td>@perfectnightmare; @MusicalRose; @JenieB(x2)
+</td>
+</tr>
+<tr>
+<td>asl
+</td>
+<td>Marshmallow Slime
+</td>
+<td>Boss HP=400; Str=1.5
+</td>
+<td>@MusicalRose; @JenieB
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>Rock
+</td>
+<td>Boss HP=400; Str=1.5
+</td>
+<td>@MusicalRose; @JenieB(x2)
+</td>
+</tr>
+<tr>
+<td>IN QUEUE
+</td>
+<td>Kangaroo
+</td>
+<td>Boss HP=700; Str=2
+</td>
+<td>@erinkidd01
+</td>
+</tr>
+<tr>
+<td>IN QUEUE
+</td>
+<td>Dolphin
+</td>
+<td>Boss HP=300; Str=1.5
+</td>
+<td>@colorcrush
+</td>
+</tr>
+<tr>
+<td>IN QUEUE
+</td>
+<td>Seahorse
+</td>
+<td>Boss HP=300; Str=1.5
+</td>
+<td>@colorcrush
+</td>
+</tr>
+<tr>
+<td>IN QUEUE
+</td>
+<td>Robot
+</td>
+<td>collection
+</td>
+<td>@erinkidd01
+</td>
+</tr>
+</tbody>
+</table>
+<p><br>
+</p>
+<p><u>EQUIPMENT QUESTS:</u>
+</p>
+<table border="1" cellspacing="0" cellpadding="1" width="0">
+<tbody>
+<tr>
+<td width="120" valign="top">
+<p><a target="_blank" rel="noreferrer noopener" class="external text" href="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=5">VOTE</a>
+</p>
+</td>
+<td width="246" valign="top">
+<p><u><b>quest name</b></u>
+</p>
+</td>
+<td width="220" valign="top">
+<p><u><b>difficulty</b></u>
+</p>
+</td>
+<td width="399" valign="top">
+<p><u><b>reward</b></u>
+</p>
+</td>
+<td width="121" valign="top">
+<p><u><b>owner</b></u>
+</p>
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Attack of the Mundane Part 1
+</td>
+<td width="220" valign="top">collection
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">main reward is the quest-owner gets a scroll for the next quest in this series; participants get 7 gold and 50 xp</span></p>
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">Part 3 of this quest series gives a piece of <b>Legendary Equipment</b>.</span></p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Corgi_Potato<br>@x4ojM<br>@hello-titania<br>@Antonbury<br>@colorcrush(x2)<br>@thegrandanomaly<br>@FunkyLittleUnicorn @Midnight_Reverie(x7)<br>
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Attack of the Mundane Part 2
+</td>
+<td width="220" valign="top">Boss HP=300; Str=1
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">main reward is the quest-owner gets a scroll for the next quest in this series; participants get 20 gold and 100 xp</span></p>
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">The next quest (Part 3) gives a reward of a piece of <b>Legendary Equipment</b> called the Nameless Helm.</span></p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Vice Part 1
+</td>
+<td width="220" valign="top">Boss HP=750; Str=1.5
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">main reward is the quest-owner gets a scroll for the next quest in this series; participants get 20 gold and 100 xp</span></p>
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">Part 3 of this quest series gives a piece of <b>Legendary Equipment</b>.</span></p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@JenieB<br>@Corgi_Potato<br>@hello-titania(x2)<br>@x4ojM(x3)<br>@Antonbury<br>@colorcrush(x2)<br>@thegrandanomaly<br>@zoomymoth<br>@FunkyLittleUnicorn @Midnight_Reverie(x7)<br>
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Vice Part 2
+</td>
+<td width="220" valign="top">collection
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">main reward is the quest-owner gets a scroll for the next quest in this series; participants get 20 gold and 75 xp</span></p>
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">The next quest (Part 3) gives a reward of a piece of <b>Legendary Equipment</b></span></p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@JenieB
+</td>
+</tr>
+<tr>
+<td>
+</td>
+<td>Vice Part 3
+</td>
+<td>Boss HP=1500; Str=3
+</td>
+<td>
+<b>LEGENDARY EQUIPMENT:</b> Stephen Weber\'s Shaft of the Dragon (gives +25 STR AND +25 PER)
+<p>2 dragon eggs
+</p>
+<p>2 shade hatching potions
+</p>
+</td>
+<td>@Perfectnightmare
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">The Golden Knight Part 1
+</td>
+<td width="220" valign="top">collection
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">main reward is the quest-owner gets a scroll for the next quest in this series; participants get 15 gold and 120 xp</span></p>
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">Part 3 of this quest series gives a piece of <b>Legendary Equipment</b>.</span></p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">
+<p>@x4ojM(x3)<br>@Corgi_Potato<br>@hello-titania<br>@PerfectNightmare<br>@Antonbury<br>@thegrandanomaly<br>@colorcrush(x2)<br>@zoomymoth<br>@FunkyLittleUnicorn<br>@erinkidd01 @Midnight_Reverie(x7)
+</p>
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">Erin
+</td>
+<td width="246" valign="top">Recidivate Part 1
+</td>
+<td width="220" valign="top">collection quest
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">main reward is the quest-owner gets a scroll for the next quest in this series; participants get 50 gold and 100 xp</span></p>
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">Part 3 of this quest series gives a piece of <b>Legendary Equipment</b>.</span></p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@x4ojM(x3)<br>@Corgi_Potato<br>@hello-titania<br>@JenieB<br>@Antonbury<br>@thegrandanomaly<br>@colorcrush(x2)<br>@FunkyLittleUnicorn<br>@erinkidd01 @Midnight_Reverie(x7)
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Recidivate Part 2
+</td>
+<td width="220" valign="top">Boss HP=1500; Str=3
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">main reward is the quest-owner gets a scroll for the next quest in this series; participants get 500 gold and 1000 xp</span></p>
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">The next quest (Part 3) gives a reward of a piece of <b>Legendary Equipment</b>.</span></p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@perfectnightmare
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Dilatory Distress Part 1
+</td>
+<td width="220" valign="top">collection quest
+</td>
+<td width="399" valign="top">Finned Oceanic Armor +15 STR
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@x4ojM<br>@JenieB<br>@Corgi_Potato<br>@erinkidd01
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Dilatory Distress Part 2
+</td>
+<td width="220" valign="top">Boss HP=500; Str=1
+<p>Rage= at 50 it heals itself for 30% of its remaining health
+</p>
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;">Fire Coral Circlet (headgear) +15 PER</p>
+<p style="text-align: left;">Skeleton hatching potion</p>
+<p style="text-align: left;">Blue cotton candy hatching potion</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@Corgi_Potato<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Dilatory Distress Part 3
+</td>
+<td width="220" valign="top">Boss HP=1000, Str=2
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;">Trident of Crashing Tides (+15 INT)</p>
+<p style="text-align: left;">Moonpearl Shield (+15 CON)</p>
+<p style="text-align: left;">(Also 3 Fish)</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@Corgi_Potato<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Mayhem in Mistiflying Part 1
+</td>
+<td width="220" valign="top">Boss HP=500; Str=1
+<p>Rage=at 50 it heals itself for 30% of its remaining health
+</p>
+</td>
+<td width="399" valign="top">Roguish Rainbow Messenger Robes +15 STR
+<p>Skeleton hatching potion
+</p>
+<p>White hatching potion
+</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Corgi_Potato<br>@Sanicks<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Mayhem in Mistiflying Part 2
+</td>
+<td width="220" valign="top">collection quest
+</td>
+<td width="399" valign="top">Roguish Rainbow Messenger Hood +15 CON
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Corgi_Potato<br>@Sanicks<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Mayhem in Mistiflying Part 3
+</td>
+<td width="220" valign="top">Boss HP=1000; Str=2
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;">Roguish Rainbow Message (main-hand weapon) +15 PER</p>
+<p style="text-align: left;">Roguish Rainbow Message (off-hand weapon) +15 INT</p>
+<p style="text-align: left;">3 x Pink Cotton Candy</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@Corgi_Potato<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Terror in the Taskwoods Part 1
+</td>
+<td width="220" valign="top">Boss HP=500; Str=1
+<p>Rage=at 50 it heals itself for 30% of its remaining health
+</p>
+</td>
+<td width="399" valign="top">Pyromancer\xe2\x80\x99s Turban +15 STR
+<p>Skeleton hatching potion
+</p>
+<p>Red hatching potion
+</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@JenieB<br>@Corgi_Potato<br>@Sanicks<br>@x4ojM<br>@FunkyLittleUnicorn @Midnight_Reverie
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Terror in the Taskwoods Part 2
+</td>
+<td width="220" valign="top">collection quest
+</td>
+<td width="399" valign="top">Pyromancer\xe2\x80\x99s Robes +15 CON
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@Corgi_Potato<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Terror in the Taskwoods Part 3
+</td>
+<td width="220" valign="top">Boss HP=1000; Str=2
+</td>
+<td width="399" valign="top">Taskwoods Latern (2-handed weapon) +15 INT AND +15 PER<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">3 x Strawberries</span></p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@Corgi_Potato<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Stoikalm Calamity Part 1
+</td>
+<td width="220" valign="top">Boss HP=500; Str=1
+<p>Rage=at 50 it heals itself for 30% of its remaining health
+</p>
+</td>
+<td width="399" valign="top">Mammoth Rider Armor +15 CON
+<p>Skeleton hatching potion
+</p>
+<p>Desert hatching potion
+</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@JenieB<br>@Sanicks<br>@x4ojM<br>@FunkyLittleUnicorn
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Stoikalm Calamity Part 2
+</td>
+<td width="220" valign="top">collection quest
+</td>
+<td width="399" valign="top">Mammoth Rider\xe2\x80\x99s Helm +15 PER
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Stoikalm Calamity Part 3
+</td>
+<td width="220" valign="top">Boss HP=1000; Str=2
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;">Mammoth Rider\xe2\x80\x99s Spear +15 INT</p>
+<p style="text-align: left;">Mammoth Rider\xe2\x80\x99s Horn +15 STR</p>
+<p style="text-align: left;">3 x Blue Cotton Candy</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@Corgi_Potato<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Mystery of the Masterclassers Part 1
+</td>
+<td width="220" valign="top">collection quest
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;">Potato x 3;</p>
+<p style="text-align: left;">Meat x 3;</p>
+<p style="text-align: left;">Milk x 3</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks
+<p>@Corgi_Potato<br>@x4ojM
+</p>
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Mystery of the Masterclassers Part 2
+</td>
+<td width="220" valign="top">Boss HP=1500; Str=2.5
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;">Aether Mask (Eyewear) +10 INT [worn in addition to helmet];</p>
+<p style="text-align: left;">Chocolate x 3;</p>
+<p style="text-align: left;">Honey x 3;</p>
+<p style="text-align: left;">Rotten Meat x 3</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@x4ojM<br>@Corgi_Potato
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Mystery of the Masterclassers Part 3
+</td>
+<td width="220" valign="top">
+<p style="text-align: left;">Boss HP=2000; Str=3</p>
+<p style="text-align: left;">rage=25 (for every 25 points of cumulative damage the boss does to the party it heals itself for 30% of its remaining health)</p>
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;">Aether Amulet (Body Accessory) +10 CON AND +10 STR [worn in addition to armor];</p>
+<p style="text-align: left;">Base hatching potion;</p>
+<p style="text-align: left;">Cotton Candy Pink hatching potion;</p>
+<p style="text-align: left;">Golden hatching potion;</p>
+<p style="text-align: left;">Shade hatching potion;</p>
+<p style="text-align: left;">Zombie hatching potion;</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@Corgi_Potato<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Mystery of the Masterclassers Part 4
+</td>
+<td width="220" valign="top">
+<p style="text-align: left;">HP=3000; Str=4</p>
+rage=15 (for every 15 points of cumulative damage the boss inflicts on the party, it also drains ALL of the party\xe2\x80\x99s mana. <b><u>THIS MEANS IF WE LOSE 15HP HEALERS CANNOT HEAL AND NO ONE CAN GIVE BUFFS UNTIL MANA REGENERATES</u></b>)<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">strategy IN BRIEF: save mana before quest, use all mana as soon as quest starts. <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://docs.google.com/document/d/1swn5ieXbmhqIeVhLO9K32ZBZYbG9QJ1W9vS72Yc5jqA/edit?usp=sharing">(CLICK HERE FOR FULL STRATEGY)</a></span></p>
+</td>
+<td width="399" valign="top">
+<p style="text-align: left;">Aether Cloak (Back Accessory) +10 PER [worn in addition to armor]</p>
+<p style="text-align: left;">Aether Crystals (Two-Handed Weapon) +10 everything</p>
+<p style="text-align: left;">Invisible Aether Mount (mount)</p>
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@Corgi_Potato<br>@x4ojM
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Lunar Battle Part 1
+</td>
+<td width="220" valign="top">collection quest
+</td>
+<td width="399" valign="top">Lunar Helm +7 STR &amp; +7 INT
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@JenieB<br>@colorcrush<br>@zoomymoth @Midnight_Reverie
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Lunar Battle Part 2
+</td>
+<td width="220" valign="top">Boss HP=100; Str=1.5
+</td>
+<td width="399" valign="top">Lunar Warrior Armor +7 CON AND +7 STR
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@JenieB<br>@colorcrush<br>@thegrandanomaly<br>@zoomymoth @Midnight_Reverie
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Lunar Battle Part 3
+</td>
+<td width="220" valign="top">Boss HP=1000; Str=2
+</td>
+<td width="399" valign="top">Lunar Scythe (2-handed weapon) +7 PER AND +7 STR
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@Sanicks<br>@MusicalRose<br>@colorcrush<br>@thegrandanomaly<br>@zoomymoth @Midnight_Reverie
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">The Basi-List
+</td>
+<td width="220" valign="top">Boss HP=100; Str=0.5
+</td>
+<td width="399" valign="top">8 gold, 42 xp
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@x4ojM(x29)<br>@JenieB(x19)<br>@colorcrush(x3)<br>@FunkyLittleUnicorn<br>@erinkidd01(x4)
+</td>
+</tr>
+<tr>
+<td width="120" valign="top">
+</td>
+<td width="246" valign="top">Feral Dust Bunnies
+</td>
+<td width="220" valign="top">Boss HP=100; Str=0.5
+</td>
+<td width="399" valign="top">8 gold, 42 xp
+</td>
+<td width="\xe2\x80\x9c121\xe2\x80\x9d" valign="top">@thegrandanomaly @Midnight_Reverie
+</td>
+</tr>
+</tbody>
+</table>
+<p><br>
+</p>
+<p>&#8194;
+</p>
+<h3>
+<span class="mw-headline" id="Completed_Quests">Completed Quests</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=6" class="mw-editsection-visualeditor" title="Edit section: Completed Quests">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=6" title="Edit section: Completed Quests"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<p>A list of all our completed quests (including date of completion) in chronological order can be seen&#160;<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://docs.google.com/document/d/1Bpsr5MHm7QYNgKWT2zwgNRj51kqUPOM0tfS0LQO4Ebg/edit?usp=sharing">here</a>.
+</p>
+<p>In the tables that can be opened by clicking on the tabs below, you can see how many times the party completed each quest. The sections are sorted in the same way as the <a href="/wiki/Quest_Shop" title="Quest Shop">Quest Shop</a> ordered them.
+</p>
+<div id="tabber-0a7223eb55c0de4b241cfcc18e0c2ae7" class="tabber">
+			<div class="tabbertab" title="Collapse Tabs">
+				<p>Default view is collapsed to make the wiki page more streamlined. Please click another tab to see completed quests.
+</p>
+<table>
+<tbody><tr><td></td></tr></tbody>
+</table>
+<p class="mw-empty-elt"></p>
+			</div>
+			<div class="tabbertab" title="Unlockable">
+				<p>An <a href="/wiki/Quests#Unlockable_Quests" title="Quests">unlockable quest</a>&#160;is received for free when a Habitica player reaches certain milestones, so everyone got a chance to get them.
+</p>
+<table border="0" cellspacing="1" cellpadding="1" style="width: 650px;" class="article-table">
+
+<tbody>
+<tr>
+<th scope="col" style="text-align:center;">Quest Line
+</th>
+<th scope="col" style="text-align:center;">Part 1
+</th>
+<th scope="col" style="text-align:center;">Part 2
+</th>
+<th scope="col" style="text-align:center;">Part 3
+</th>
+</tr>
+<tr>
+<td>
+<a href="/wiki/Quest_lines#Lunar_Battle_Quest_Line" class="mw-redirect" title="Quest lines">Lunar Battle</a>
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Find_the_Mysterious_Shards" title="Find the Mysterious Shards">Find the Mysterious Shards</a> (2)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Stop_the_Overshadowing_Stress" title="Stop the Overshadowing Stress">Stop the Overshadowing Stress</a> (2)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/The_Monstrous_Moon" title="The Monstrous Moon">The Monstrous Moon</a> (3)
+</td>
+</tr>
+<tr>
+<td>
+<a href="/wiki/Quest_Lines#Attack_of_the_Mundane_Quest_Line" title="Quest Lines">Attack of the Mundane</a>
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Dish_Disaster!" title="Dish Disaster!">Dish Disaster!</a> (2)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/The_SnackLess_Monster" title="The SnackLess Monster">The SnackLess Monster</a> (2)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/The_Laundromancer" title="The Laundromancer">The Laundromancer</a> (4)
+</td>
+</tr>
+<tr>
+<td>
+<a href="/wiki/Quest_lines#Vice_Quest_Line" class="mw-redirect" title="Quest lines">Vice</a>
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Free_Yourself_of_the_Dragon%27s_Influence" title="Free Yourself of the Dragon's Influence">Free Yourself of the Dragon\'s Influence</a> (2)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Find_the_Lair_of_the_Wyrm" title="Find the Lair of the Wyrm">Find the Lair of the Wyrm</a> (3)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Vice_Awakens" title="Vice Awakens">Vice Awakens</a> (4)
+</td>
+</tr>
+<tr>
+<td>
+<a href="/wiki/Quest_lines#The_Golden_Knight_Quest_Line" class="mw-redirect" title="Quest lines">Golden Knight</a>
+</td>
+<td style="text-align:center;">
+<a href="/wiki/A_Stern_Talking-To" title="A Stern Talking-To">A Stern Talking-To</a> (3)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Gold_Knight" title="Gold Knight">Gold Knight</a> (4)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/The_Iron_Knight" title="The Iron Knight">The Iron Knight</a> (5)
+</td>
+</tr>
+<tr>
+<td>
+<a href="/wiki/Quest_lines#Recidivate_Quest_Line" class="mw-redirect" title="Quest lines">Recidivate</a>
+</td>
+<td style="text-align:center;">
+<a href="/wiki/The_Moonstone_Chain" title="The Moonstone Chain">The Moonstone Chain</a> (2)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Recidivate_the_Necromancer" title="Recidivate the Necromancer">Recidivate the Necromancer</a> (3)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Recidivate_Transformed" title="Recidivate Transformed">Recidivate Transformed</a> (3)
+</td>
+</tr>
+</tbody>
+</table>
+<p class="mw-empty-elt"></p>
+			</div>
+			<div class="tabbertab" title="Gold-Purchasable">
+				<p>Gold-Purchasable Quest Lines
+</p>
+<table border="0" cellspacing="1" cellpadding="1" style="width: 650px;" class="article-table">
+
+<tbody>
+<tr>
+<th scope="col" style="text-align:center;">Quest Line
+</th>
+<th scope="col" style="text-align:center;">Part 1
+</th>
+<th scope="col" style="text-align:center;">Part 2
+</th>
+<th scope="col" style="text-align:center;">Part 3
+</th>
+</tr>
+<tr>
+<td>
+<a href="/wiki/Quest_Lines#Dilatory_Distress_Quest_Line" title="Quest Lines">Dilatory Distress</a>
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Message_in_a_Bottle" title="Message in a Bottle">Message in a Bottle</a> (6)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Creatures_of_the_Crevasse" title="Creatures of the Crevasse">Creatures of the Crevasse</a> (7)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Not_a_Mere_Maid" title="Not a Mere Maid">Not a Mere Maid</a> (9)
+</td>
+</tr>
+<tr>
+<td>
+<a href="/wiki/Quest_Lines#Terror_in_the_Taskwoods_Quest_Line" title="Quest Lines">Terror in the Taskwoods</a>
+</td>
+<td style="text-align:center;">
+<a href="/wiki/The_Blaze_in_the_Taskwoods" title="The Blaze in the Taskwoods">The Blaze in the Taskwoods</a> (4)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Finding_the_Flourishing_Fairies" title="Finding the Flourishing Fairies">Finding the Flourishing Fairies</a> (5)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Jacko_of_the_Lantern" title="Jacko of the Lantern">Jacko of the Lantern</a> (4)
+</td>
+</tr>
+<tr>
+<td>
+<a href="/wiki/Quest_Lines#Sto.C3.AFkalm_Calamity_Quest_Line" title="Quest Lines">Stoikalm Calamity</a>
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Earthen_Enemies" title="Earthen Enemies">Earthen Enemies</a> (4)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Seek_the_Icicle_Caverns" title="Seek the Icicle Caverns">Seek the Icicle Caverns</a> (4)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Icicle_Drake_Quake" title="Icicle Drake Quake">Icicle Drake Quake</a> (4)
+</td>
+</tr>
+<tr>
+<td>
+<a href="/wiki/Quest_Lines#Mayhem_in_Mistiflying_Quest_Line" title="Quest Lines">Mayhem in Mistiflying</a>
+</td>
+<td style="text-align:center;">
+<a href="/wiki/In_Which_Mistiflying_Experiences_a_Dreadful_Bother" title="In Which Mistiflying Experiences a Dreadful Bother">In Which Mistiflying Experiences a Dreadful Bother</a> (4)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/In_Which_the_Wind_Worsens" title="In Which the Wind Worsens">In Which the Wind Worsens</a> (5)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/In_Which_a_Mailman_is_Extremely_Rude" title="In Which a Mailman is Extremely Rude">In Which a Mailman is Extremely Rude</a> (4)
+</td>
+</tr>
+</tbody>
+</table>
+<p class="mw-empty-elt"></p>
+			</div>
+			<div class="tabbertab" title="Masterclasser">
+				<p>The Mystery of the Masterclassers
+</p>
+<table border="0" cellspacing="1" cellpadding="1" style="width:500px;" class="article-table">
+
+<tbody>
+<tr>
+<th scope="col" style="text-align:center;">Part 1
+</th>
+<th scope="col" style="text-align:center;">Part 2
+</th>
+<th scope="col" style="text-align:center;">Part 3
+</th>
+<th scope="col" style="text-align:center;">Part 4
+</th>
+</tr>
+<tr>
+<td style="text-align:center;">
+<a href="/wiki/Read_Between_the_Lines" title="Read Between the Lines">Read Between the Lines</a> (30)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/Assembling_the_aVoidant" title="Assembling the aVoidant">Assembling the aVoidant</a> (8)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/City_in_the_Sands" title="City in the Sands">City in the Sands</a> (3)
+</td>
+<td style="text-align:center;">
+<a href="/wiki/The_Lost_Masterclasser" title="The Lost Masterclasser">The Lost Masterclasser</a> (3)
+</td>
+</tr>
+</tbody>
+</table>
+<p class="mw-empty-elt"></p>
+			</div>
+			<div class="tabbertab" title="Hatching Potions">
+				<p>Magic Hatching Potion Quests
+</p>
+<table border="0" cellspacing="1" cellpadding="1" style="width:500px;" class="article-table">
+
+<tbody>
+<tr>
+<th scope="col" style="text-align:left;">Type of potion: Quest Name (times completed)
+</th>
+</tr>
+<tr>
+<td style="text-align:left;">Silver hatching potions: <a href="/wiki/The_Silver_Solution" title="The Silver Solution">The Silver Solution</a> (12)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Bronze hatching potions: <a href="/wiki/Brazen_Beetle_Battle" title="Brazen Beetle Battle">Brazen Beetle Battle</a> (10)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Amber hatching potions: <a href="/wiki/The_Amber_Alliance" title="The Amber Alliance">The Amber Alliance</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Ruby hatching potions: <a href="/wiki/Ruby_Rapport" title="Ruby Rapport">Ruby Rapport</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Confection hatching potions: <a href="/wiki/Waffling_with_the_Fool:_Disaster_Breakfast!" title="Waffling with the Fool: Disaster Breakfast!">Waffling with the Fool: Disaster Breakfast!</a> (4)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Fluorite hatching potions: <a href="/wiki/A_Bright_Fluorite_Fright" title="A Bright Fluorite Fright">A Bright Fluorite Fright</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Turquoise hatching potions: <a href="/wiki/Turquoise_Treasure_Toil" title="Turquoise Treasure Toil">Turquoise Treasure Toil</a> (7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Black Pearl hatching potions: <a href="/wiki/A_Startling_Starry_Idea" title="A Startling Starry Idea">A Startling Starry Idea</a> (7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Wind-Up hatching potions [hourglass quest]: <a href="/wiki/A_Whirl_with_a_Wind-Up_Warrior" title="A Whirl with a Wind-Up Warrior">A Whirl with a Wind-Up Warrior</a> (2)
+</td>
+</tr>
+</tbody>
+</table>
+<p class="mw-empty-elt"></p>
+			</div>
+			<div class="tabbertab" title="Pets">
+				<p>Pet Quests (in order of release)
+</p>
+<table border="0" cellspacing="1" cellpadding="1" style="width:500px;" class="article-table">
+
+<tbody>
+<tr>
+<th scope="col" style="text-align:left;">Pet Name - Quest Name (times completed)
+</th>
+</tr>
+<tr>
+<td style="text-align:left;">Gryphon - <a href="/wiki/The_Fiery_Gryphon" title="The Fiery Gryphon">The Fiery Gryphon</a> (10)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Hedgehog - <a href="/wiki/The_Hedgebeast" title="The Hedgebeast">The Hedgebeast</a>	(9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Deer - <a href="/wiki/The_Spirit_of_Spring" title="The Spirit of Spring">The Spirit of Spring</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Rat - <a href="/wiki/The_Rat_King" title="The Rat King">The Rat King</a> (7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Octopus - <a href="/wiki/The_Call_of_Octothulu" title="The Call of Octothulu">The Call of Octothulu</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Seahorse - <a href="/wiki/The_Dilatory_Derby" title="The Dilatory Derby">The Dilatory Derby</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Parrot - <a href="/wiki/Help!_Harpy!" title="Help! Harpy!">Help! Harpy!</a>	(9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Rooster - <a href="/wiki/Rooster_Rampage" title="Rooster Rampage">Rooster Rampage</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Spider - <a href="/wiki/The_Icy_Arachnid" title="The Icy Arachnid">The Icy Arachnid</a>	(8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Owl - <a href="/wiki/The_Night-Owl" title="The Night-Owl">The Night-Owl</a> (10)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Penguin - <a href="/wiki/The_Fowl_Frost" title="The Fowl Frost">The Fowl Frost</a> (11)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">T-Rex - <a href="/wiki/The_Dinosaur_Unearthed" title="The Dinosaur Unearthed">The Dinosaur Unearthed</a> or <a href="/wiki/King_of_the_Dinosaurs" title="King of the Dinosaurs">King of the Dinosaurs</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Rock - <a href="/wiki/Escape_the_Cave_Creature" title="Escape the Cave Creature">Escape the Cave Creature</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Bunny - <a href="/wiki/The_Killer_Bunny" title="The Killer Bunny">The Killer Bunny</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Egg - <a href="/wiki/Egg_Hunt" title="Egg Hunt">Egg Hunt</a> [seasonal quest, gives 10 eggs] (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Marshmallow Slime (aka "Slime") - <a href="/wiki/The_Jelly_Regent" title="The Jelly Regent">The Jelly Regent</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Sheep - <a href="/wiki/The_Thunder_Ram" title="The Thunder Ram">The Thunder Ram</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Cuttlefish - <a href="/wiki/The_Kraken_of_Inkomplete" title="The Kraken of Inkomplete">The Kraken of Inkomplete</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Whale - <a href="/wiki/Wail_of_the_Whale" title="Wail of the Whale">Wail of the Whale</a>	(8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Cheetah - <a href="/wiki/Such_a_Cheetah" title="Such a Cheetah">Such a Cheetah</a> (7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Horse - <a href="/wiki/Ride_the_Night-Mare" title="Ride the Night-Mare">Ride the Night-Mare</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Frog - <a href="/wiki/Swamp_of_the_Clutter_Frog" title="Swamp of the Clutter Frog">Swamp of the Clutter Frog</a> (7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Snake - <a href="/wiki/The_Serpent_of_Distraction" title="The Serpent of Distraction">The Serpent of Distraction</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Unicorn - <a href="/wiki/Convincing_the_Unicorn_Queen" title="Convincing the Unicorn Queen">Convincing the Unicorn Queen</a> (12)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Sabretooth - <a href="/wiki/The_Sabre_Cat" title="The Sabre Cat">The Sabre Cat</a> (7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Monkey - <a href="/wiki/Monstrous_Mandrill_and_the_Mischief_Monkeys" title="Monstrous Mandrill and the Mischief Monkeys">Monstrous Mandrill and the Mischief Monkeys</a> (7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Snail - <a href="/wiki/The_Snail_of_Drudgery_Sludge" title="The Snail of Drudgery Sludge">The Snail of Drudgery Sludge</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Falcon - <a href="/wiki/The_Birds_of_Preycrastination" title="The Birds of Preycrastination">The Birds of Preycrastination</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Treeling - <a href="/wiki/The_Tangle_Tree" title="The Tangle Tree">The Tangle Tree</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Axolotl - <a href="/wiki/The_Magical_Axolotl" title="The Magical Axolotl">The Magical Axolotl</a>	(9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Turtle - <a href="/wiki/Guide_the_Turtle" title="Guide the Turtle">Guide the Turtle</a>	(10)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Armadillo - <a href="/wiki/The_Indulgent_Armadillo" title="The Indulgent Armadillo">The Indulgent Armadillo</a> (7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Cow - <a href="/wiki/The_Mootant_Cow" title="The Mootant Cow">The Mootant Cow</a>	(8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Beetle - <a href="/wiki/The_CRITICAL_BUG" title="The CRITICAL BUG">The CRITICAL BUG</a>	(7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Ferret - <a href="/wiki/The_Nefarious_Ferret" title="The Nefarious Ferret">The Nefarious Ferret</a>	(7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Sloth - <a href="/wiki/The_Somnolent_Sloth" title="The Somnolent Sloth">The Somnolent Sloth</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Triceratops - <a href="/wiki/The_Trampling_Triceratops" title="The Trampling Triceratops">The Trampling Triceratops</a> (7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Guinea Pig - <a href="/wiki/The_Guinea_Pig_Gang" title="The Guinea Pig Gang">The Guinea Pig Gang</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Peacock - <a href="/wiki/The_Push-and-Pull_Peacock" title="The Push-and-Pull Peacock">The Push-and-Pull Peacock</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Butterfly/Caterpillar - <a href="/wiki/Bye,_Bye,_Butterfry" title="Bye, Bye, Butterfry">Bye, Bye, Butterfry</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Nudibranch - <a href="/wiki/Infestation_of_the_NowDo_Nudibranchs" title="Infestation of the NowDo Nudibranchs">Infestation of the NowDo Nudibranchs</a>	(9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Hippo - <a href="/wiki/What_a_Hippo-Crite" title="What a Hippo-Crite">What a Hippo-Crite</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Yarn - <a href="/wiki/A_Tangled_Yarn" title="A Tangled Yarn">A Tangled Yarn</a>	(10)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Pterodactyl - <a href="/wiki/The_Pterror-dactyl" title="The Pterror-dactyl">The Pterror-dactyl</a> (9)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Badger - <a href="/wiki/Stop_Badgering_Me!" title="Stop Badgering Me!">Stop Badgering Me!</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Squirrel - <a href="/wiki/The_Sneaky_Squirrel" title="The Sneaky Squirrel">The Sneaky Squirrel</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Sea Serpent - <a href="/wiki/Danger_in_the_Depths:_Sea_Serpent_Strike!" title="Danger in the Depths: Sea Serpent Strike!">Danger in the Depths: Sea Serpent Strike!</a> (11)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Kangaroo - <a href="/wiki/Kangaroo_Catastrophe" title="Kangaroo Catastrophe">Kangaroo Catastrophe</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Alligator - <a href="/wiki/The_Insta-Gator" title="The Insta-Gator">The Insta-Gator</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Velociraptor - <a href="/wiki/The_Veloci-Rapper" title="The Veloci-Rapper">The Veloci-Rapper</a> (8)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Dolphin - <a href="/wiki/The_Dolphin_of_Doubt" title="The Dolphin of Doubt">The Dolphin of Doubt</a> (7)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">Robot - <a href="/wiki/Mysterious_Mechanical_Marvels!" title="Mysterious Mechanical Marvels!">Mysterious Mechanical Marvels!</a> [hourglass quest] (4)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">SPECIAL: Polar bear cub (no eggs) - <a href="/wiki/Find_the_Cub" title="Find the Cub">Find the Cub</a> [seasonal quest] (4)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">SPECIAL: Polar bear mount (no eggs) - <a href="/wiki/Trapper_Santa" title="Trapper Santa">Trapper Santa</a> [seasonal quest] (5)
+</td>
+</tr>
+</tbody>
+</table>
+<p class="mw-empty-elt"></p>
+			</div>
+</div>
+<p>&#8194;
+</p>
+<p>&#8194;
+</p>
+<h3><span class="mw-headline" id="Quest_Resources">Quest Resources</span></h3>
+<h4><span class="mw-headline" id="Auto_Accept_Quest_Instructions">Auto Accept Quest Instructions</span></h4>
+<p>Never ever want to miss a quest?&#160; Install this google script and your Habitica account will automatically accept every quest invitation that the party sends out!&#160; Be aware that if you install this, you will almost always be on a quest, so your undone dailies will almost always harm the party, so only install this if you are willing to stay in the Inn if you miss many.&#160; Instructions for installation given in the link below:
+</p>
+<p><b><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://docs.google.com/document/d/e/2PACX-1vR71C0hAJ6ZBqBrbP8eiVioNvoXugr_CUpT2ClbUj1RqfcEwokUDoaOv4sQBKdDxzHjAbHjo7J47Kxo/pub">INSTRUCTIONS LINK</a></b>
+</p>
+<h4><span class="mw-headline" id="Damage_Calculator">Damage Calculator</span></h4>
+<p>Do you want to know how much damage your undone dailies will do to the party if you don\xe2\x80\x99t stay in the Inn?
+</p>
+<p>Use <b><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://oldgods.net/habitrpg/habitrpg_user_data_display.html">THIS TOOL</a></b> to find out!
+</p>
+<p>Once you enter your Habitica User ID &amp; API Token, the damage your current undone dailies will do to the party will appear in the 4th of 5 rectangles along the top of the screen. If you need help using the tool, a more detail explanation is available <b><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://docs.google.com/document/d/1pwkJecSM7S8_3de1kDQtScI134u00-4Lci8pS1Z5AnE/edit?usp=sharing">HERE</a>&#160; A Word of Warning:&#160;If you have not logged in to Habitica for over a day, your damage to the party will actually be MUCH HIGHER than the tool says.</b>
+</p>
+<h4><span class="mw-headline" id="Damage_Tables">Damage Tables</span></h4>
+<p>Once a quest has already started, you can find out how much damage your undone dailies would do to the party if you don\xe2\x80\x99t stay at the Inn by using the Damage Calculator Tool - linked directly above! But what if the quest has not started yet, but you know it WILL start before the next time you log in? How can you know how much damage your undone dailies will do to the party in that case? You can calculate it yourself with <b><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://docs.google.com/document/d/1sXYsiuv6JzyZh1KBYHHAcFsKsRBgO3RnIQCsm2Rgg2Q/edit?usp=sharing">these tables</a></b>! &#160; 
+&#8194;
+</p>
+<p><br>
+</p>
+<h2><span class="mw-headline" id="Participating_in_Party_Chat">Participating in Party Chat</span></h2>
+<p>PLEASE NOTE THAT THIS SECTION IS CURRENTLY IN DRAFT MODE!!!!
+</p>
+<h3><span class="mw-headline" id="The_goals_of_this_section:">The goals of this section:</span></h3>
+<ul>
+<li>To provide guidelines to clarify what it means to "be respectful" (and thus acceptable in chat)</li>
+<li>To give tips to boost your chatting-confidence so that you can better take advantage of our party\'s #1 most valuable resource: interactions with other party members.</li>
+</ul>
+<p><br>
+</p>
+<h3>
+<span id="The_3_main_ways_we_participate_in_chat_(outside_of_challenges):"></span><span class="mw-headline" id="The_3_main_ways_we_participate_in_chat_.28outside_of_challenges.29:">The 3 main ways we participate in chat (outside of challenges):</span>
+</h3>
+<ol>
+<li>Speaking your feelings. Sharing what you are dealing with, emotionally and situationally. Share both the good and the bad.</li>
+<li>Responding to others, helping them feel heard.</li>
+<li>Posting positive content such as cute animal pictures or inspiring quotes. Telling us what made you laugh today, or what happened that made you smile.</li>
+</ol>
+<p>Below are notes relating to each of these in turn.
+</p>
+<h3>
+<span id="Notes,_tips,_guidelines"></span><span class="mw-headline" id="Notes.2C_tips.2C_guidelines">Notes, tips, guidelines</span>
+</h3>
+<p>1a) Profanity: In general, profanity is NOT off-limits: We DO request that it be kept to a minimum, but also acknowledge that it can be cathartic to swear and do not want party members to feel censored. Vent when you need to.
+</p>
+<p>1b) Religious terminology: While it might be ok to say the F-word if you need to blow off some steam, it is asked that people refrain from using the term "OMG". Some members of our party are more religiously inclined than others. Some value their religion as something essential to getting them through dark times, and they feel greatly saddened when others disrespect their beliefs. It might be difficult to understand why someone else would be offended by such a common phrase, but we do not need to understand WHY a person is hurt, it is enough to know that they ARE. Out of respect for those members of our party who are upset by casual/blasphemous invocation (even in acronym form) of their deity, try to remember to say "gosh" instead. Swearing is ok if you need to, but please keep your swears secular.
+</p>
+<p>1c) Trigger Warnings: Many of the topics we deal with are topics that can be upsetting. It is good to talk about them, but for the sake of those who are feeling fragile and do not want to read about certain things we ask that you use trigger warnings on the first line of your post if it involves any of the following subjects: suicide, eating disorder issues,&#160;?????????
+</p>
+<p>2a) Respond to others\' successes by cheering them on. Give a virtual high five. Tell people how awesome they are. Even something as small as clicking the "like" button on a post can make a person feel validated.
+</p>
+<p>2b) Responding to others\' struggles might seem more difficult, but know that you do not have to offer solutions in order to respond to another member\'s problems. Simply acknowledging that what they are going through must be very hard is a way to help them feel heard and cared about. Simply saying "that sucks, I\'m so sorry" can be better than saying nothing, and is a perfectly valid response. Even clicking the "like" button can be a way to respond. It can feel strange to "like" another person\'s pain, but think of it as saying "I like the fact that you were brave enough to share this with us." Clicking the like button lets the person who made the post know that it has been read, that they have been listened to.
+</p>
+<p>2c) Avoid "Should Statements". If you DO want to give advice to a fellow party member, try to avoid wording your suggestions as "You should do _____." Instead, ask them "Have you tried doing ___?" or "I\'ve heard that doing ___ can be helpful in situations like that" or "I had a problem like that once and something that helped me was doing ___ , maybe that could help you too."
+</p>
+<p>2d) Don\'t overwhelm yourself with feeling like you need to respond to everything!
+</p>
+<p>3)????
+</p>
+<p><br>
+</p>
+<h2><span class="mw-headline" id="Party_Challenges">Party Challenges</span></h2>
+<p>&#8194;
+</p>
+<h3>
+<span class="mw-headline" id="Current_Party_Challenges">Current Party Challenges</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=7" class="mw-editsection-visualeditor" title="Edit section: Current Party Challenges">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=7" title="Edit section: Current Party Challenges"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<p>&#8194;
+</p>
+<p><b>1.&#160; PRIVATE PROFILES - ongoing, guaranteed gems to every participant </b> <i>created by asl @x4ojM (part 1) with collaboration from Little Bear (Jen) @JenieB (parts 2 &amp; 3),&#160;gem sponsor: Little Bear (Jen) @JenieB</i>
+</p>
+<p>Party members have expressed a desire for a having a way to share information about themselves that cannot be accessed by anyone outside our party. This long awaited feature has finally arrived.
+</p>
+<p>Please share with us information that lets us know who you are and what struggles have brought you to this party. The point of these profiles is multiple. First, to let us all get to know each other a little better so we can empathize with each other\'s struggles, know some each others situations and histories, celebrate each others strengths and achievements, and learn some of that important other stuff too: like who owns cats, who loves anime, who speaks another language. Second this is a channel for the healing that comes from speaking openly, an outlet to tell our stories (as much or as little of them as we choose) in our own words without fear of judgement.
+</p>
+<p>These 2 goals are embodied by part 1 of the challenge (as it is laid out in the official challenge description). Parts 2 and 3 of the challenge were added to address a Third goal: To try to figure out how can we best help each other. We may not even know what we want or need from this party or in general, but Parts 2 and 3 ask members to consider some questions, and try to provide at least some brief answers.
+</p>
+<p>Completing the challenge involves writing responses to at least part 1, formatting your answers according to instructions in the official challenge description to ensure privacy, then telling me where your answers are, what your preferred pronouns are and what timezone you\'re in. If you only want to write for Part 1 you will still get 1 gem. If you write responses to all 3 parts, you will get 2 gems.
+</p>
+<p><b>2.&#160; SHARING SAT/SUN/MON&#160;- recreated each week so gems AND achievement badges can be awarded to a random participant each week &#160;</b> <i>creator:&#160;Little Bear (Jen) @JenieB, gem sponsor: Little Bear (Jen) @JenieB, administrator: </i>Antonbury<i> @</i>Antonbury
+</p>
+<p>Questions every weekend to share with each other what we have accomplished, a goal for the following week, and a different fun fact about ourselves each week. Posting positive comments in party chat throughout the entire week is also encouraged in this challenge. This challenge has been a perennial favorite since it was first introduced in early February of 2019. In order for achievement badges to be awarded to winners, a new version of this challenge is created each week, so remember to join the new challenge every week!
+</p>
+<p><b>3.&#160; FANCY FRIDAYS - gems awarded each week&#160;</b> <i>creator: asl @x4ojM, gem sponsor: @Rachael2Worlds, administrator: asl @x4ojM</i>
+</p>
+<p>Fun is the keyword here! This challenge is all about dressing up your avatar and telling the party about the scene you created (see some example scene descriptions <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://docs.google.com/document/d/1OCq4GQyYdHC-LrE7aCq9EuevH2NK9AvRMHg9Bh0a_GQ/edit?usp=sharing">HERE</a> ). Sign up now for a chance at gems each week (winner chosen by random.org).
+</p>
+<p><b>4. Mid-Week Check-In Challenge&#160;- gems awarded each week&#160;</b> <i>creator: asl&#160;@x4ojM, gem sponsor: @Kyrison, administrator: @Rachael2Worlds</i>
+</p>
+<p>Helping each other accomplish&#160;the goals we set during the "Sharing Sat/Sun/Mon" challenge (or any other weekly goals you set for yourself) by keeping each other accountable and setting up a habit to help remind&#160;ourselves of the goal so we don\'t simply forget!&#160; Whether you\'ve met your goal every day or none of the days, whether you\'ve completed it or made no progress at all.&#160;You have an equal chance of winning the challenge regardless of your progress (or lack thereof) - the challenge is simply&#160;to report to the party and let us know in party chat how things are going.&#160;&#160;If they\'re going well, we can congratulate you;&#160;if you\'re struggling, we might be able to offer suggestions (or at least condolences and empathy).&#160;
+</p>
+<p><b>5.&#160; "LIBRARY OF..." - Resources disguised as challenges!&#160;</b> <i>creators: kim @lynxicon &amp; Little Bear (Jen) @JenieB, administrator: kim @lynxicon</i>
+</p>
+<p>This set of 4 challenges (Library of dailies; Library of habits; Library of rewards;&#160;and Library of Gamified Tasks) are <i><b>not meant to be joined!</b></i>&#160;
+</p>
+<p>Rather the challenges serve as a place to store compiled lists of the dailies, habits, custom rewards, and tasks with "gamified" wording that different party members use and have found to be helpful to them.&#160;Look at the lists to get ideas for things that you&#160;might want to add&#160;to your own tasks or set as a custom reward for yourself.&#160;If there is a habit, daily, gamified task, or custom reward that YOU use that ISN\'T on the lists, send a PM to&#160;@lynxicon and she can add it to the list for others to benefit from!
+</p>
+<p><br>
+</p>
+<p><br>
+</p>
+<h3><span class="mw-headline" id="Old_Party_Challenges">Old Party Challenges</span></h3>
+<p><br>
+<b>1.&#160; BUILDING BATTLE BUDDIES (Our party\'s very first challenge!!) [now closed - superceded by PRIVATE PROFILES (we still want to know your preferred pronouns, so please tell us by participating in the new PRIVATE PROFILES challenge!!)] </b> <i>created by Little Bear (Jen) @JenieB&#160;</i>
+</p>
+<p>Out of the blue I received a PM from someone asking if I knew of a good party focused on mental health. That question lead to the creation of this party as well as the first challenge. BUILDING BATTLE BUDDIES was designed to help the party get to know each other, figure out how to best help each other, and establish what we were all looking for in a party. To win a gem, post something from each of these 3 topics in party chat.&#160;AWARD WINNERS INCLUDED:&#160;Neala - 1 extra gem for being first to complete challenge,&#160;Stevie Oberg, Rain (Rose), x4ojM, Kyrison - donated gem back to party,&#160;
+</p>
+<p><b>2.&#160; PREFERRED PRONOUNS [now closed - superceded by PRIVATE PROFILES (we still want to know your preferred pronouns, so please tell us by participating in the new PRIVATE PROFILES challenge!!)]&#160;</b> <i>created by asl @x4ojM</i>
+</p>
+<p>Pronouns are important, and I try never to assume what pronouns I should use to refer to someone based on what their username is or what their avatar looks like, so I\xe2\x80\x99d appreciate it if you all let me know how you want to be referred to: as she/her, he/him, they/them, ze/zir, or something else. Our party wiki page has a member list you can add yourself to, and there\'s a&#160;spot there for stating your preferred pronouns.&#160;Please add yourself and your pronouns to the list!&#160;&#160;
+</p>
+<p><b>3.&#160; FORGING CHALLENGES [now closed, but if you have any ideas for future challenges you\'d like to see please still tell @JenieB what they are in a PM]&#160;</b><i>created by Little Bear (Jen) @JenieB</i>
+</p>
+<p>This challenge was created to get some ideas and teams together to create future challenges.&#160;
+</p>
+<h2>
+<span class="mw-headline" id="Misc._Habitica_Resources">Misc. Habitica Resources</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=8" class="mw-editsection-visualeditor" title="Edit section: Misc. Habitica Resources">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=8" title="Edit section: Misc. Habitica Resources"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h2>
+<h3><span class="mw-headline" id="Avatar_Preview_Tool">Avatar Preview Tool</span></h3>
+<p>There is a tool online that lets you preview any pet/mount/background/equipment/etc that you want. And they have all the items (including magical potion pets/mounts) available for preview as soon as they are available in-game (which means they have newly released magical potion pets/mounts available for preview <b>BEFORE</b>&#160;the pictures of them get added to the wiki). Seeing what new magical potion animals look like before images of them are posted on the wiki is what most people in the party seem to use the tool for.
+</p>
+<p>Personally I use it most often to preview what certain scenes might look like against backgrounds I have not bought yet to help me decide if I really want to buy the backgrounds or not. Also, sometimes I use the tool to generate random avatar scenes (this happens whenever you reload the page, OR when you click the \xe2\x80\x9crandomize\xe2\x80\x9d button at the bottom of the page) just because they can be amusing to look at.
+</p>
+<p>The \xe2\x80\x9cAvatar Preview Tool\xe2\x80\x9d is located at <a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://crookedneighbor.github.io/habitica-avatar/">https://crookedneighbor.github.io/habitica-avatar/</a>
+</p>
+<p>Some IMPORTANT tips:
+</p>
+<ul>
+<li>
+<b>You don\'t have to select every detail for the scene you create.</b> If you want to do something like see what new magical pets look like you can leave everything else alone (the options will just remain set to the random choices the site loaded them with) and just choose the pet/mount you want to see, click the "Make Avatar" at the bottom. <b>If you are on mobile, you will then have to scroll back up and to the right to actually see the result. </b>(This used to be the case on computer browsers as well, but that issue has recently been fixed for most computer browsers).</li>
+<li>There are a LOT of choices in the pets/mounts selection menus, so it can be hard to find the one you want, but <b>they are organized in a particular order</b> - first comes the \xe2\x80\x9cnone\xe2\x80\x9d option, then the basic pets/mounts in the basic hatching potion colors, then come the basic pets/mounts in all of the magical hatching potion colors (in order by when the potion was released - so a brand new potion would be the very last option listed for that animal), then come the quest pets/mounts, and lastly the "special" things like the Invisible Aether mount or the jackalope pet.&#160; &#160;<span style="font-family:Calibri;font-size:small;">[NOTE: Order may be subject to change! In the past, the basic pets/mounts were all grouped together, so the list started with \xe2\x80\x9cnone\xe2\x80\x9d then \xe2\x80\x9cbase wolf\xe2\x80\x9d and went on to list all the basic hatching potion versions of wolf followed immediately by the magical hatching potions for wolf. Now, the basic pets/mounts are separated: the basic colors of wolf are followed by the basic colors of tiger, and then panda, and so on, with the magical hatching potions for wolf starting after all the basic colors of all the basic animals.]</span>
+</li>
+</ul>
+<p><br>
+&#8194;
+</p>
+<h2>
+<span id="Recommended_Guilds_&amp;_Guild_Challenges"></span><span class="mw-headline" id="Recommended_Guilds_.26_Guild_Challenges">Recommended Guilds &amp; Guild Challenges</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=9" class="mw-editsection-visualeditor" title="Edit section: Recommended Guilds &amp; Guild Challenges">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=9" title="Edit section: Recommended Guilds &amp; Guild Challenges"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h2>
+<ul>
+<li>
+<b><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/groups/guild/e1dc1efe-1cdc-4a7c-ac76-189fd434a236">Living Vividly</a> - </b>They have new challenges each month. The challenges reflect around&#160;joy, connection, and mindfulness for building resilience.</li>
+<li>
+<b><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/groups/guild/1da5ae22-6659-4600-9951-905f923c9373">Anxiety Alliance</a></b> &#160;- A&#160;very large guild with active chat, a good place to go to talk if you\'re stressed about something and no one is online in party chat to help.&#160;They also have 2 awesome challenges&#160;every single month: a "Do the Scary Thing" challenge, and a "Meditiation" challenge.</li>
+<li>
+<b><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/groups/guild/54846572-9b87-421c-a2f5-11f72ee8ecfc">Mentally ill</a> -</b> Good chatroom, challenges include:<b>&#160;</b>Make a comfort box, Stopping self harm, Just Do It, 3 meals a day, &amp; many others&#160;(most run indefinitely, no gem prizes)</li>
+<li>
+<b><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/groups/guild/033c9ff6-6fe2-4a94-8bd9-0f4fbbec104e">Life Basics</a></b> - With 3 separate&#160;gem-prize challenges each month for&#160;brushing your teeth twice every day,&#160;taking a shower every day, and taking a daily walk, plus other non-gem-prize challenges that can be helpful as well</li>
+<li>
+<b>The Onion Patch</b>&#160;<b>-&#160;</b>They have new challenges each month. The challenges relfect on&#160;self-care and creating/strengthen meaningful emotional connections.</li>
+<li>
+<b>A Silly Place -&#160;</b>The Silliness Challenge</li>
+<li>
+<b>Playing with Power: Nintendo of Habitica -&#160;</b>They have&#160;new challenges each month to celebrate love for nintendo games.</li>
+<li>
+<b>Awesome Introverts -&#160;</b>Recharge mindfully</li>
+<li>
+<b>Kindness -&#160;</b>Smile, Be Kind to Yourself!, Be Brave and Conquer Your Fears</li>
+<li>
+<b><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/groups/guild/de98b936-44a3-47a8-b83a-a5b8c3584e79">Be Kind to Yourself Guild</a></b> - Good Work!,&#160;Self-compassion,&#160;Done is better than perfect!, Selfcare,&#160;Constructive Self-Talk</li>
+<li>
+<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/groups/guild/109d5b3f-661f-49cf-ad1d-53de129ecaf5"><b>Mastering Emotions (DBT Skills)</b></a> - They have many challenges, most of which run indefinitely.</li>
+<li>
+<b>The Chronic Illness Guild - </b>Make a Change,&#160;Keep an Accomplishment Diary</li>
+<li>
+<b>Autistic Adventurers\' Guild</b>&#160;<b>-</b>&#160;Executive Dysfunction Blues</li>
+<li>
+<b>ADHDers Guild - </b>Break it down!</li>
+<li>
+<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://habitica.com/groups/guild/00ea45dd-45bd-4dff-9652-caf5033041b1"><b>Venture outside your lair </b>\xf0\x9f\x8c\xbf</a> - To help you get out of the house!</li>
+<li>
+<b>Knights of Academia</b> - They have new self improvement/self discipline&#160;challenges each week. The&#160;list of past ones are <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://knightsofacademia.org/">here</a>
+</li>
+<li>
+<b>Knights of the Prayerful Rose (Catholic/Christian Habiticans and their friends) -&#160;</b>This guild has a very friendly atmosphere.&#160;The guild leader is very helpful if you have any questions. ~ Pray before&#160;meals, Add some silence to your prayer life!</li>
+<li>
+<b>UNFREEZE the Freeze Response, CPTSD and truama (no/minium triggers)</b> - Unfreeze the Freeze Response 2.0, I Have the Right!</li>
+<li>
+<b>Flow</b> -&#160;Making a Hard Task Easier,&#160;Done is better than perfect!</li>
+<li>
+<b>Minimalism -&#160;</b>Treat Yo\' Self, Minimalist Tidy</li>
+<li>
+<b>52 Weeks -&#160;</b>Self care</li>
+<li>
+<b>Complusive Overeaters and Co. -&#160;</b>Me and the Food (happy and healthy relationship), Mindful Eating, I went to the shop and bought only the things I had planned to buy</li>
+<li>
+<b>The BFRB Guild</b> - BFRB Beginner Challenge, BFRB Expert Challenge, Redirection, Lirbary of BFRB Task Ideas</li>
+<li>
+<b>Mindfulness and Relaxation</b> - Beginning Meditation Resources, Twice Daliy Meditation&#160;</li>
+<li>
+<b>ExtraBoost - Get the boost you need for the life you want - </b>(These challenges aren\'t limited to just guild members.&#160;The guild leader of this guild did make them.) ~<b>&#160;</b>Read Every Day, Keep a dairy, Pomodoro Technique Habit</li>
+<li>
+<b>Pen Pals -&#160;</b>Pen Pals Challenge</li>
+<li>
+<b>Short-Term Goal Accountability - </b>Weekly Focus Finder,&#160;Out and About Bingo,&#160;Save Wilma the Whale!</li>
+<li><b>Long Term Project Guild&#160;</b></li>
+<li><b>Life Basics</b></li>
+<li><b>The Bulletin Board&#160;</b></li>
+</ul>
+<p><br>
+</p>
+<h3>
+<span class="mw-headline" id="Other_Recommended_Challenges">Other Recommended Challenges</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=10" class="mw-editsection-visualeditor" title="Edit section: Other Recommended Challenges">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=10" title="Edit section: Other Recommended Challenges"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<p>These challenges are not associated with any guild, but usually renew&#160;each month (or every quarter month)&#160;in the "discover challenges" tab.&#160;If you use the search feature under \xe2\x80\x9cfind challenges\xe2\x80\x9d you should be able to access them.
+</p>
+<ul><li>The Being Kinder to Yourself Challenge</li></ul>
+<ul><li>Devoted Year</li></ul>
+<ul><li>Daily Gratitude</li></ul>
+<ul><li>Seasonal Affective Disorder</li></ul>
+<p><br>
+</p>
+<h2>
+<span class="mw-headline" id="In_case_of_emergency...">In case of emergency...</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=11" class="mw-editsection-visualeditor" title="Edit section: In case of emergency...">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=11" title="Edit section: In case of emergency..."><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h2>
+<ul>
+<li><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://mental-health-advice.tumblr.com/helplines">Helplines</a></li>
+<li><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://mental-health-advice.tumblr.com/web-counselling">Web Counselling</a></li>
+<li><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://mental-health-advice.tumblr.com/reasons-to-stay">Reasons To Stay</a></li>
+<li><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://mental-health-advice.tumblr.com/SH/reasons-not-to">Reasons not to Self-Harm</a></li>
+<li><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://mental-health-advice.tumblr.com/SH/alternatives">Alternatives to Self Harm</a></li>
+<li><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://mental-health-advice.tumblr.com/calming">Calming Anxiety and Panic</a></li>
+<li><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://mental-health-advice.tumblr.com/anger-management">Managing Anger</a></li>
+<li><a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://mental-health-advice.tumblr.com/distractions">Distractions</a></li>
+</ul>
+<p><br>
+</p>
+<h2>
+<span class="mw-headline" id="Mental_Health_Resources">Mental Health Resources</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=12" class="mw-editsection-visualeditor" title="Edit section: Mental Health Resources">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=12" title="Edit section: Mental Health Resources"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h2>
+<h3>
+<span class="mw-headline" id="Subsection_1:_Youtube_Videos">Subsection 1: Youtube Videos</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=13" class="mw-editsection-visualeditor" title="Edit section: Subsection 1: Youtube Videos">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=13" title="Edit section: Subsection 1: Youtube Videos"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<pre>   Please feel free to add more videos! &#160;&#160;
+</pre>
+<p>-&#160;&#160;sometimes when you feel stuck sitting in a chair like you can\xe2\x80\x99t even get up (I have been there) the 5-4-3-2-1-Go method explained in this video can help:&#160;<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="//youtu.be/i129CFqBIzg">https://youtu.be/i129CFqBIzg</a>&#160; &#160;
+</p>
+<p>-&#160;the short version of Kristen Neff\xe2\x80\x99s TED talk on self-compassion vs. self-esteem. It is a video&#160;I would recommend to everyone:&#160;<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="//youtu.be/IvtZBUSplr4">https://youtu.be/IvtZBUSplr4</a>
+</p>
+<p><br>
+&#160;
+</p>
+<h3>
+<span class="mw-headline" id="Subsection_2:_Inspirational_Image_Gallery">Subsection 2: Inspirational Image Gallery</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=14" class="mw-editsection-visualeditor" title="Edit section: Subsection 2: Inspirational Image Gallery">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=14" title="Edit section: Subsection 2: Inspirational Image Gallery"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<pre>   Please feel free to add more images! (just click the button below the gallery)
+</pre>
+<p><br>
+</p>
+<ol><li><ol><li><b>CURRENTLY&#160;EXPERIENCING COPYRIGHT INFRINGEMENT DIFFICULTIES</b></li></ol></li></ol>
+<p><br>
+</p>
+<p><br>
+</p>
+<p><br>
+</p>
+<p><br>
+</p>
+<p><br>
+</p>
+<h3>
+<span class="mw-headline" id="Subsection_3:_Links">Subsection 3: Links</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=15" class="mw-editsection-visualeditor" title="Edit section: Subsection 3: Links">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=15" title="Edit section: Subsection 3: Links"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<pre>   Please feel free to add more links!
+</pre>
+<p>- Cute animal gifs to look at when you are feeling down: <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="http://animalygifs.tumblr.com/">http://animalygifs.tumblr.com/archive</a>
+</p>
+<p>- Good website with mental health related articles <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="//themighty.com">https://themighty.com</a>
+</p>
+<p>- Real stories, real lives <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="//yourockfoundation.org">http://yourockfoundation.org</a>
+</p>
+<p>- Awesome cute comics, makes me laugh so hard <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="https://www.instagram.com/nathanwpylestrangeplanet/?fbclid=IwAR1CxbljQ1d4rc_4LjXNNDjaJ5_fBB7q4dwDuE3YxGi2To1tiSKY0YxXOSY">https://www.instagram.com/nathanwpylestrangeplanet/</a>
+</p>
+<p>-&#160;An&#160;online community where people share what they\'ve been through and what they\'ve learned to help themselves and others&#160;<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="//tinybuddha.com/">https://tinybuddha.com/</a>
+</p>
+<p>- App/website for mental health&#160;<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="//www.thinkpacifica.com/">https://www.thinkpacifica.com/</a>
+</p>
+<p>- About others\' victories and to share your own <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="//mental-health-advice.tumblr.com/accomplishments">https://mental-health-advice.tumblr.com/accomplishments</a>
+</p>
+<p>- Reasons why other fellow warriors have not given up <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="//mental-health-advice.tumblr.com/i-wont-give-up">https://mental-health-advice.tumblr.com/i-wont-give-up</a>
+</p>
+<p>- To share all those things people said to hurt you, and defy them <a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="//mental-health-advice.tumblr.com/they-were-wrong">https://mental-health-advice.tumblr.com/they-were-wrong</a>
+</p>
+<p>- Encouragement to reach out for help&#160;<a target="_blank" rel="nofollow noreferrer noopener" class="external text" href="//mental-health-advice.tumblr.com/how-help-helps">https://mental-health-advice.tumblr.com/how-help-helps</a>
+</p>
+<p>- Cute cat article <a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.buzzfeednews.com/article/ryanhatesthis/safe-haven-pet-sanctuary">https://www.buzzfeednews.com/article/ryanhatesthis/safe-haven-pet-sanctuary</a>
+</p>
+<p><br>
+</p>
+<h3>
+<span id="Subsection_4:_Stay_home,_Stay_busy"></span><span class="mw-headline" id="Subsection_4:_Stay_home.2C_Stay_busy">Subsection 4: Stay home, Stay busy</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=16" class="mw-editsection-visualeditor" title="Edit section: Subsection 4: Stay home, Stay busy">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=16" title="Edit section: Subsection 4: Stay home, Stay busy"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h3>
+<p>As above Subsections, feel free to add links and ideas!
+</p>
+<p>I tried to include only resources that offer free content.
+</p>
+<p><u>Arts and entertainment:</u><br>
+<a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.operadeparis.fr/actualites/spectacles-de-lopera-de-paris-a-redecouvrir-en-ligne">https://www.operadeparis.fr/actualites/spectacles-de-lopera-de-paris-a-redecouvrir-en-ligne</a>
+<a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.metopera.org/">https://www.metopera.org/</a>
+<a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.berliner-philharmoniker.de/en/titelgeschichten/20192020/digital-concert-hall/">https://www.berliner-philharmoniker.de/en/titelgeschichten/20192020/digital-concert-hall/</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://artsandculture.google.com/streetview/solomon-r-guggenheim-museum-interior-streetview/jAHfbv3JGM2KaQ?hl=en&amp;sv_lng=-73.95902634325634&amp;sv_lat=40.78285751667664&amp;sv_h=30.75703204567916&amp;sv_p=0.06928383072430222&amp;sv_pid=MfnUmHRyOSzMtY3vtYU05g&amp;sv_z=0.9645743015259166">https://artsandculture.google.com/streetview/solomon-r-guggenheim-museum-interior-streetview/jAHfbv3JGM2KaQ?hl=en&amp;sv_lng=-73.95902634325634&amp;sv_lat=40.78285751667664&amp;sv_h=30.75703204567916&amp;sv_p=0.06928383072430222&amp;sv_pid=MfnUmHRyOSzMtY3vtYU05g&amp;sv_z=0.9645743015259166</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://artsandculture.google.com/partner/national-gallery-of-art-washington-dc?hl=en">https://artsandculture.google.com/partner/national-gallery-of-art-washington-dc?hl=en</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://artsandculture.google.com/partner/musee-dorsay-paris?hl=en">https://artsandculture.google.com/partner/musee-dorsay-paris?hl=en</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://artsandculture.google.com/partner/national-museum-of-modern-and-contemporary-art-korea?hl=en">https://artsandculture.google.com/partner/national-museum-of-modern-and-contemporary-art-korea?hl=en</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://artsandculture.google.com/entity/pergamon/m05tcm?hl=en">https://artsandculture.google.com/entity/pergamon/m05tcm?hl=en</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://artsandculture.google.com/partner/van-gogh-museum?hl=en">https://artsandculture.google.com/partner/van-gogh-museum?hl=en</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://artsandculture.google.com/partner/the-j-paul-getty-museum?hl=en">https://artsandculture.google.com/partner/the-j-paul-getty-museum?hl=en</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://artsandculture.google.com/partner/uffizi-gallery?hl=en">https://artsandculture.google.com/partner/uffizi-gallery?hl=en</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://artsandculture.google.com/partner/masp?hl=en">https://artsandculture.google.com/partner/masp?hl=en</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://artsandculture.google.com/asset/the-national-museum-of-anthropology-mexico-city-ziko-van-dijk-wikimedia-commons/bAGSHRdlzSRcdQ?hl=en">https://artsandculture.google.com/asset/the-national-museum-of-anthropology-mexico-city-ziko-van-dijk-wikimedia-commons/bAGSHRdlzSRcdQ?hl=en</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.louvre.fr/en/visites-en-ligne">https://www.louvre.fr/en/visites-en-ligne</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.lelombard.com/actualite/actualites/confinement-albums-gratuits">https://www.lelombard.com/actualite/actualites/confinement-albums-gratuits</a>&#160;
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://tokybook.com/">https://tokybook.com/</a>
+</p>
+<p><br>
+</p>
+<p><u>Video Games:</u>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://itch.io/s/28565/stay-safe-folks-">https://itch.io/s/28565/stay-safe-folks-</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://steamdb.info/sales/?min_discount=95&amp;min_rating=0">https://steamdb.info/sales/?min_discount=95&amp;min_rating=0</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://free.ubisoft.com/">https://free.ubisoft.com/</a>
+</p>
+<p><br>
+</p>
+<p><u>Education, Science, Knowledge:</u>
+<a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://explore.org/livecams">https://explore.org/livecams</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.zooniverse.org/">https://www.zooniverse.org/</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="http://www.webexhibits.org/causesofcolor/index.html">http://www.webexhibits.org/causesofcolor/index.html</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.uncensoredlibrary.com/en">https://www.uncensoredlibrary.com/en</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://about.jstor.org/oa-and-free/">https://about.jstor.org/oa-and-free/</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://plannedparenthood.tumblr.com/post/613765015747592192/sex-ed-at-home-planned-parenthood-has-got-you">https://plannedparenthood.tumblr.com/post/613765015747592192/sex-ed-at-home-planned-parenthood-has-got-you</a>
+</p>
+<p><br>
+</p>
+<p><u>Excercising</u>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://ymca360.org/">https://ymca360.org/</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://shop.lululemon.com/story/at-home-workouts">https://shop.lululemon.com/story/at-home-workouts</a>
+</p>
+<p><br>
+</p>
+<p><u>Arts and Crafts, DIY:</u>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://blog.colettehq.com/tutorials/make-do-and-mend-darning">https://blog.colettehq.com/tutorials/make-do-and-mend-darning</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://catmeme.tumblr.com/post/188552542683/sew-on-all-the-paws-ears-tail-etc-using-the">https://catmeme.tumblr.com/post/188552542683/sew-on-all-the-paws-ears-tail-etc-using-the</a>
+</p>
+<p><br>
+</p>
+<p><u>Quarantine-specific Mental health Articles, Lists, and Other:</u>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://www.psychologytools.com/articles/free-guide-to-living-with-worry-and-anxiety-amidst-global-uncertainty/?highlight=living+with+worry+and+anxiety+amidst+global+uncertainty&amp;fbclid=IwAR0YToiA%5Cxe2%5Cx80%5Cx93L9SVPVXrQV8Y-BcdsgMZDo6RK7ZyVc7XwxxzEk-ZgNDvFR0B8">https://www.psychologytools.com/articles/free-guide-to-living-with-worry-and-anxiety-amidst-global-uncertainty/?highlight=living+with+worry+and+anxiety+amidst+global+uncertainty&amp;fbclid=IwAR0YToiA\xe2\x80\x93L9SVPVXrQV8Y-BcdsgMZDo6RK7ZyVc7XwxxzEk-ZgNDvFR0B8</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://marst-n.tumblr.com/post/612594044015722496/stuck-at-home-heres-an-isolation-survival-post">https://marst-n.tumblr.com/post/612594044015722496/stuck-at-home-heres-an-isolation-survival-post</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://lielith.tumblr.com/post/612805548964036608/covid19-entertainment-masterpost-the-met-opera-is">https://lielith.tumblr.com/post/612805548964036608/covid19-entertainment-masterpost-the-met-opera-is</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://howtogeton.wordpress.com/love-discounts-in-the-time-of-coronavirus/">https://howtogeton.wordpress.com/love-discounts-in-the-time-of-coronavirus/</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://compassionatereminders.tumblr.com/post/187025732704/if-you-dont-have-means-to-a-therapist-or-mental">https://compassionatereminders.tumblr.com/post/187025732704/if-you-dont-have-means-to-a-therapist-or-mental</a>
+</p>
+<p><a target="_blank" rel="nofollow noreferrer noopener" class="external free" href="https://science-junkie.tumblr.com/post/135865769347/itsrosewho-famous-authors-classic">https://science-junkie.tumblr.com/post/135865769347/itsrosewho-famous-authors-classic</a>
+</p>
+<p><br>
+</p>
+<h2>
+<span id="MORE?"></span><span class="mw-headline" id="MORE.3F">MORE?</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?veaction=edit&amp;section=17" class="mw-editsection-visualeditor" title="Edit section: MORE?">edit</a><span class="mw-editsection-divider"> | </span><a href="/wiki/The_Keep:Mental_Health_Warriors_Unite?action=edit&amp;section=17" title="Edit section: MORE?"><svg class="wds-icon wds-icon-tiny section-edit-pencil-icon"><use xlink:href="#wds-icons-pencil-tiny"></use></svg>edit source</a><span class="mw-editsection-bracket">]</span></span>
+</h2>
+<p>MORE FORTHCOMING?
+</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>&#8194;</p>
+<p>==Sandbox for code testing==
+</p>
+<p><br>
+</p>
+<p><br>
+</p>
+<p style="text-align: left;"><span style="font-family:Calibri;font-size:small;">Use this code to make text small</span></p>
+<p><br>
+</p>
+<p><br>
+</p>
+<p><br>
+</p>
+<p><br>
+</p>
+<p><br>
+</p>
+<p><br>
+(end of sandbox)
+</p>
+<!-- 
+NewPP limit report
+Cached time: 20210419130408
+Cache expiry: 1209600
+Dynamic content: false
+CPU time usage: 0.126 seconds
+Real time usage: 0.142 seconds
+Preprocessor visited node count: 303/1000000
+Preprocessor generated node count: 0/1000000
+Post\xe2\x80\x90expand include size: 235/2097152 bytes
+Template argument size: 73/2097152 bytes
+Highest expansion depth: 3/40
+Expensive parser function count: 0/100
+Unstrip recursion depth: 0/20
+Unstrip post\xe2\x80\x90expand size: 9833/5000000 bytes
+-->
+<!--
+Transclusion expansion time report (%,ms,calls,template)
+100.00%   15.850      1 -total
+ 84.90%   13.457      1 Template:Infobox_class
+ 14.59%    2.313      1 Template:Forumheader
+-->
+
+<!-- Saved in parser cache with key prod:habitrpg:pcache:idhash:54892-0!canonical and timestamp 20210419130408 and revision id 159309
+ -->
+</div>
+</div>								<div class="printfooter">Retrieved from "<a dir="ltr" href="https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite?oldid=159309">https://habitica.fandom.com/wiki/The_Keep:Mental_Health_Warriors_Unite?oldid=159309</a>"</div>
+							</div>
+
+															<nav class="article-categories CategorySelect articlePage userCanEdit" id="articleCategories">
+	<div class="container">
+		<div class="special-categories">
+<a href="/wiki/Special:Categories" class="categoriesLink" title="Special:Categories">Categories</a>:</div>
+		<ul class="categories">
+						<li class="category normal" data-name="The Armory" data-namespace="" data-outertag="" data-sortkey="" data-type="normal">
+	<span class="name"><a href="/wiki/Category:The_Armory" title="Category:The Armory">The Armory</a></span>
+	<span class="tool removeCategory"></span>
+</li>
+			<li class="category normal" data-name="Parties" data-namespace="" data-outertag="" data-sortkey="" data-type="normal">
+	<span class="name"><a href="/wiki/Category:Parties" title="Category:Parties">Parties</a></span>
+	<span class="tool removeCategory"></span>
+</li>
+		
+							<li class="last">
+					<button class="wds-button wds-is-secondary add" id="CategorySelectAdd" type="button">Add category</button>
+				</li>
+					</ul>
+	</div>
+			<div class="toolbar">
+			<button class="wds-button wds-is-secondary cancel" id="CategorySelectCancel" type="button">Cancel</button>
+			<button class="wds-button save" id="CategorySelectSave" type="button" disabled>Save</button>
+		</div>
+	</nav>							
+																								<div class="license-description">
+		Community content is available under <a href="https://www.fandom.com/licensing">CC-BY-SA</a> unless otherwise noted.	</div>
+														<!-- render SkinAfterContent hook output - used by article comments, SMW factbox etc. -->
+														<!-- end SkinAfterContent output -->
+						</div>
+					</article>
+											
+<aside id="WikiaRailWrapper" class="WikiaRail">
+		<div id="WikiaRail" class="wikia-rail-inner">
+		<div id="rail-boxad-wrapper"></div>
+	</div>
+</aside>
+									</div>
+				<div id="mixed-content-footer" class="mcf-en" data-number-of-wiki-articles="9" data-number-of-ns-articles="10">
+	<div class="mcf-content">
+		<h1 class="mcf-header">Fan Feed		</h1>
+		<div class="mcf-mosaic">
+			<div class="mcf-column">
+									<div class="mcf-card mcf-card-wiki-articles">
+						<header class="mcf-card-wiki-articles__header">
+						<span class="mcf-card-wiki-articles__header-text">More Habitica Wiki</span>
+						</header>
+						<ul class="mcf-card-wiki-articles__list">
+														<li class="mcf-card-wiki-articles__item">
+								<a href="/wiki/Pets" class="mcf-card-wiki-articles__item-link" data-tracking="more-wiki-0" title="Pets">
+									<span class="mcf-card-wiki-articles__circle">0</span>
+									<span class="mcf-card-wiki-articles__title">Pets</span>
+								</a>
+							</li>
+														<li class="mcf-card-wiki-articles__item">
+								<a href="/wiki/Class_System" class="mcf-card-wiki-articles__item-link" data-tracking="more-wiki-1" title="Class System">
+									<span class="mcf-card-wiki-articles__circle">1</span>
+									<span class="mcf-card-wiki-articles__title">Class System</span>
+								</a>
+							</li>
+														<li class="mcf-card-wiki-articles__item">
+								<a href="/wiki/Mounts" class="mcf-card-wiki-articles__item-link" data-tracking="more-wiki-2" title="Mounts">
+									<span class="mcf-card-wiki-articles__circle">2</span>
+									<span class="mcf-card-wiki-articles__title">Mounts</span>
+								</a>
+							</li>
+													</ul>
+					</div>
+				
+									<div class="mcf-card-ns-placeholder" data-tracking="footer-card-4"></div>
+					<div class="mcf-card-wiki-placeholder" data-tracking="footer-card-7"></div>
+								<div class="mcf-card-ns-placeholder mcf-card-tall" data-tracking="footer-card-10"></div>
+				<div class="mcf-card-wiki-placeholder" data-tracking="footer-card-13"></div>
+				<div class="mcf-card-ns-placeholder" data-tracking="footer-card-16"></div>
+				<div class="mcf-card-wiki-placeholder mcf-card-tall" data-tracking="footer-card-19"></div>
+			</div>
+
+			<div class="mcf-column">
+				<div class="mcf-card-ns-placeholder mcf-card-sponsored-content" data-tracking="footer-card-2"></div>
+				<div class="mcf-card-ns-placeholder" data-tracking="footer-card-5"></div>
+				<div class="mcf-card-ns-placeholder" data-tracking="footer-card-8"></div>
+				<div class="mcf-card-wiki-placeholder" data-tracking="footer-card-11"></div>
+				<div class="mcf-card-ns-placeholder" data-tracking="footer-card-14"></div>
+				<div class="mcf-card-wiki-placeholder" data-tracking="footer-card-17"></div>
+				<div class="mcf-card mcf-card-related-wikis">
+					<header class="mcf-card-related-wikis__header">
+						Explore Wikis					</header>
+					<ul class="mcf-card-related-wikis__list">
+												<li class="mcf-card-related-wikis__item">
+							<a href="http://bit.ly/en-spotlight-universalconquest" class="mcf-card-related-wikis__item-link" data-tracking="explore-wikis-0" title="Universal Conquest Wiki">
+								<img src="https://vignette.wikia.nocookie.net/spotlightsimagestemporary/images/0/0e/UC.JPG/revision/latest?cb=20200923195325" class="mcf-card-related-wikis__item-image">
+								<div>
+									<span class="mcf-card-related-wikis__title">Universal Conquest Wiki</span>
+								</div>
+							</a>
+						</li>
+												<li class="mcf-card-related-wikis__item">
+							<a href="https://letsgoluna.fandom.com/wiki/Let%27s_Go_Luna!_Wiki" class="mcf-card-related-wikis__item-link" data-tracking="explore-wikis-1" title="Let's Go Luna! Wiki">
+								<img src="https://vignette.wikia.nocookie.net/letsgoluna/images/c/cd/Erik-Luna-article-2-copy.png/revision/latest?cb=20200327133046" class="mcf-card-related-wikis__item-image">
+								<div>
+									<span class="mcf-card-related-wikis__title">Let\'s Go Luna! Wiki</span>
+								</div>
+							</a>
+						</li>
+											</ul>
+				</div>
+			</div>
+
+			<div class="mcf-column">
+				<div class="mcf-card-wiki-placeholder" data-tracking="footer-card-3"></div>
+				<div class="mcf-card-wiki-placeholder mcf-card-tall" data-tracking="footer-card-6"></div>
+				<div class="mcf-card-wiki-placeholder" data-tracking="footer-card-9"></div>
+				<div class="mcf-card-ns-placeholder" data-tracking="footer-card-12"></div>
+				<div class="mcf-card-wiki-placeholder mcf-card-tall" data-tracking="footer-card-15"></div>
+				<div class="mcf-card-ns-placeholder" data-tracking="footer-card-18"></div>
+				<div class="mcf-card-ns-placeholder" data-tracking="footer-card-21"></div>
+			</div>
+		</div>
+	</div>
+</div>
+			</div>
+			</div>
+</div>
+<script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgPageParseReport":{"limitreport":{"cputime":"0.126","walltime":"0.142","ppvisitednodes":{"value":303,"limit":1000000},"ppgeneratednodes":{"value":0,"limit":1000000},"postexpandincludesize":{"value":235,"limit":2097152},"templateargumentsize":{"value":73,"limit":2097152},"expansiondepth":{"value":3,"limit":40},"expensivefunctioncount":{"value":0,"limit":100},"unstrip-depth":{"value":0,"limit":20},"unstrip-size":{"value":9833,"limit":5000000},"timingprofile":["100.00%   15.850      1 -total"," 84.90%   13.457      1 Template:Infobox_class"," 14.59%    2.313      1 Template:Forumheader"]},"cachereport":{"timestamp":"20210419130408","ttl":1209600,"transientcontent":false}}});});</script>
+<script defer src="https://www.fastly-insights.com/static/scout.js?k=17272cd8-82ee-4eb5-b5a3-b3cd5403f7c5"></script><script>(window.RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgBackendResponseTime":77});});</script><div id="WikiaBar">
+	<div id="WikiaBarWrapper" class="WikiaBarWrapper hidden">
+		<div class="wikia-bar wikia-bar-anon">
+				<a class="wikiabar-button" href="http://bit.ly/fandomshop1" data-index="0">
+		<span>FandomShop</span>
+	</a>
+	<a class="wikiabar-button" href="https://bit.ly/WBEmailCap" data-index="1">
+		<span>Newsletter</span>
+	</a>
+	<a class="wikiabar-button" href="https://bit.ly/PPlusWikiBar" data-index="2">
+		<span>Paramount+</span>
+	</a>
+<div here for more information find a new show to watch in seconds></div>
+			<a href="#" class="arrow" data-trigger="hover" data-tooltip="Collapse" data-tooltipshow="Show">
+				<svg class="wds-icon wds-icon-tiny"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>			</a>
+		</div>
+	</div>
+
+	<div class="WikiaBarCollapseWrapper" data-trigger="hover" data-tooltip="Collapse">
+		<svg class="wds-icon wds-icon-tiny wikia-bar-collapse"><use xlink:href="#wds-icons-menu-control-tiny"></use></svg>	</div>
+</div>
+	<footer class="wds-global-footer">
+			<h2 class="wds-global-footer__header">
+			<a href="https://www.fandom.com/" data-tracking-label="logo" title="Fandom" aria-label="Fandom homepage">
+				<svg class="wds-global-footer__header-logo"><use xlink:href="#wds-company-logo-fandom-white"></use></svg>			</a>
+		</h2>
+		<div class="wds-global-footer__main">
+		<div class="wds-global-footer__column">
+			<section class="wds-global-footer__section wds-is-fandom-overview">
+			<h3 class="wds-global-footer__section-header">Explore properties</h3>
+	
+	
+	
+			<ul class="wds-global-footer__links-list">
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.fandom.com/" class="wds-global-footer__link" data-tracking-label="explore.fandom">
+	Fandom</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.gamepedia.com/" class="wds-global-footer__link" data-tracking-label="explore.gamepedia">
+	Gamepedia</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.dndbeyond.com/" class="wds-global-footer__link" data-tracking-label="explore.dnd-beyond">
+	D&amp;D Beyond</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.cortexrpg.com/" class="wds-global-footer__link" data-tracking-label="explore.cortexrpg">
+	Cortex RPG</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.muthead.com/" class="wds-global-footer__link" data-tracking-label="explore.muthead">
+	Muthead</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.futhead.com/" class="wds-global-footer__link" data-tracking-label="explore.futhead">
+	Futhead</a>
+									</li>
+					</ul>
+	</section>
+			<section class="wds-global-footer__section wds-is-follow-us">
+			<h3 class="wds-global-footer__section-header">Follow Us</h3>
+	
+	
+	
+			<ul class="wds-global-footer__links-list">
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.facebook.com/getfandom" class="wds-global-footer__link" data-tracking-label="follow-us.facebook" aria-label="Follow Fandom on Facebook">
+	<svg class="wds-global-footer__link-image wds-icon"><use xlink:href="#wds-icons-facebook"></use></svg></a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://twitter.com/getfandom" class="wds-global-footer__link" data-tracking-label="follow-us.twitter" aria-label="Follow Fandom on Twitter">
+	<svg class="wds-global-footer__link-image wds-icon"><use xlink:href="#wds-icons-twitter"></use></svg></a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.youtube.com/fandomentertainment" class="wds-global-footer__link" data-tracking-label="follow-us.youtube" aria-label="Follow Fandom on Youtube">
+	<svg class="wds-global-footer__link-image wds-icon"><use xlink:href="#wds-icons-youtube"></use></svg></a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.instagram.com/getfandom/" class="wds-global-footer__link" data-tracking-label="follow-us.instagram" aria-label="Follow Fandom on Instagram">
+	<svg class="wds-global-footer__link-image wds-icon"><use xlink:href="#wds-icons-instagram"></use></svg></a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.linkedin.com/company/157252" class="wds-global-footer__link" data-tracking-label="follow-us.linkedin" aria-label="Follow Fandom on LinkedIn">
+	<svg class="wds-global-footer__link-image wds-icon"><use xlink:href="#wds-icons-linkedin"></use></svg></a>
+									</li>
+					</ul>
+	</section>
+		</div>
+		<div class="wds-global-footer__column">
+			<section class="wds-global-footer__section wds-is-site-overview">
+			<h3 class="wds-global-footer__section-header">Overview</h3>
+	
+	
+	
+			<ul class="wds-global-footer__links-list">
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.fandom.com/about" class="wds-global-footer__link" data-tracking-label="company-overview.about">
+	About</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.fandom.com/careers" class="wds-global-footer__link" data-tracking-label="company-overview.careers">
+	Careers</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.fandom.com/press" class="wds-global-footer__link" data-tracking-label="company-overview.press">
+	Press</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.fandom.com/about#contact" class="wds-global-footer__link" data-tracking-label="company-overview.contact">
+	Contact</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.fandom.com/terms-of-use" class="wds-global-footer__link" data-tracking-label="site-overview.terms-of-use">
+	Terms of Use</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.fandom.com/privacy-policy" class="wds-global-footer__link" data-tracking-label="site-overview.privacy-policy">
+	Privacy Policy</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="//community.fandom.com/Sitemap" class="wds-global-footer__link" data-tracking-label="site-overview.global-sitemap">
+	Global Sitemap</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="/wiki/Local_Sitemap" class="wds-global-footer__link" data-tracking-label="site-overview.local-sitemap">
+	Local Sitemap</a>
+									</li>
+					</ul>
+	</section>
+		</div>
+		<div class="wds-global-footer__column">
+			<section class="wds-global-footer__section wds-is-community">
+			<h3 class="wds-global-footer__section-header">Community</h3>
+	
+	
+	
+			<ul class="wds-global-footer__links-list">
+							<li class="wds-global-footer__links-list-item">
+											<a href="//community.fandom.com/wiki/Community_Central" class="wds-global-footer__link" data-tracking-label="community.community-central">
+	Community Central</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://fandom.zendesk.com/" class="wds-global-footer__link" data-tracking-label="community.support">
+	Support</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="//community.fandom.com/wiki/Help:Contents" class="wds-global-footer__link" data-tracking-label="community.help">
+	Help</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.fandom.com/do-not-sell-my-info" class="wds-global-footer__link" data-tracking-label="community.usp-do-not-sell">
+	Do Not Sell My Info</a>
+									</li>
+					</ul>
+	</section>
+			<section class="wds-global-footer__section wds-is-advertise">
+			<h3 class="wds-global-footer__section-header">Advertise</h3>
+	
+	
+	
+			<ul class="wds-global-footer__links-list">
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.fandom.com/mediakit" class="wds-global-footer__link" data-tracking-label="advertise.media-kit">
+	Media Kit</a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://www.fandom.com/mediakit#contact" class="wds-global-footer__link" data-tracking-label="advertise.contact">
+	Contact</a>
+									</li>
+					</ul>
+	</section>
+		</div>
+		<div class="wds-global-footer__column">
+			<section class="wds-global-footer__section wds-is-fandom-apps">
+			<h3 class="wds-global-footer__section-header">Fandom Apps</h3>
+	
+			<span class="wds-global-footer__section-description">Take your favorite fandoms with you and never miss a beat.</span>
+	
+	
+	</section>
+			<section class="wds-global-footer__section wds-is-fandom-stores">
+	
+	
+			<figure class="wds-global-footer__image">
+	<svg class="wds-icon"><use xlink:href="#wds-company-store-logo-fandom"></use></svg>	</figure>
+
+	
+			<ul class="wds-global-footer__links-list">
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://apps.apple.com/us/app/fandom-videos-news-reviews/id1230063803" class="wds-global-footer__link" data-tracking-label="community-apps.app-store" aria-label="Fandom's Apple Store">
+	<svg class="wds-global-footer__link-image wds-icon"><use xlink:href="#wds-company-store-appstore"></use></svg></a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://play.google.com/store/apps/details?id=com.fandom.app&amp;referrer=utm_source%3Dwikia%26utm_medium%3Dglobalfooter" class="wds-global-footer__link" data-tracking-label="community-apps.google-play" aria-label="Fandom's Google Play">
+	<svg class="wds-global-footer__link-image wds-icon"><use xlink:href="#wds-company-store-googleplay"></use></svg></a>
+									</li>
+					</ul>
+	</section>
+			<section class="wds-global-footer__section wds-is-ddb-stores">
+	
+	
+			<figure class="wds-global-footer__image">
+	<svg class="wds-icon"><use xlink:href="#wds-company-store-logo-ddb"></use></svg>			<figcaption class="wds-global-footer__image-caption">
+			D&amp;D Beyond		</figcaption>
+	</figure>
+
+	
+			<ul class="wds-global-footer__links-list">
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://apps.apple.com/us/app/id1501810129" class="wds-global-footer__link" data-tracking-label="community-apps.app-store-ddb" aria-label="D&amp;D Beyond's Apple Store">
+	<svg class="wds-global-footer__link-image wds-icon"><use xlink:href="#wds-company-store-appstore"></use></svg></a>
+									</li>
+							<li class="wds-global-footer__links-list-item">
+											<a href="https://play.google.com/store/apps/details?id=com.fandom.playercompanion&amp;referrer=utm_source%3Dwikia%26utm_medium%3Dglobalfooter" class="wds-global-footer__link" data-tracking-label="community-apps.google-play-ddb" aria-label="D&amp;D Beyond's Google Play">
+	<svg class="wds-global-footer__link-image wds-icon"><use xlink:href="#wds-company-store-googleplay"></use></svg></a>
+									</li>
+					</ul>
+	</section>
+		</div>
+	</div>
+	<div class="wds-global-footer__bottom-bar">
+		<div class="wds-global-footer__bottom-bar-row wds-has-padding">Habitica Wiki is a FANDOM Games Community.</div>
+
+					<div class="global-footer-bottom mobile-site-link">
+	<a href class="global-footer-bottom__link wds-font-size-xs wds-font-weight-bold wds-leading-tight wds-text-transform-uppercase">
+		View Mobile Site	</a>
+</div>
+			</div>
+
+</footer>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="height: 0px; width: 0px; position: absolute; overflow: hidden;" aria-hidden="true"><defs><path id="pencil-tiny" d="M8.5 6.086L5.914 3.5 7 2.414 9.586 5 8.5 6.086zM4.586 10H2V7.414l2.5-2.5L7.086 7.5l-2.5 2.5zm7.121-5.707l-4-4a.999.999 0 0 0-1.414 0l-6 6A1 1 0 0 0 0 7v4a1 1 0 0 0 1 1h4c.265 0 .52-.105.707-.293l6-6a.999.999 0 0 0 0-1.414z"></path><path id="trash-tiny" d="M10 4a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V5a1 1 0 0 1 2 0v5h2V5a1 1 0 0 1 2 0v5h2V5a1 1 0 0 1 1-1zm1-3a1 1 0 0 1 0 2H1a1 1 0 0 1 0-2h3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3z"></path><path id="flag-small" d="M3 11h10.586l-3.293-3.293a.999.999 0 0 1 0-1.414L13.586 3H3v8zm-1 7a1 1 0 0 1-1-1V1a1 1 0 0 1 2 0h13a1.002 1.002 0 0 1 .707 1.707L12.414 7l4.293 4.293A1 1 0 0 1 16 13H3v4a1 1 0 0 1-1 1z"></path><path id="alert-small" d="M2.618 15.995L9 3.199l6.382 12.796H2.618zm15.276.554l-8-16.04C9.555-.17 8.445-.17 8.105.51l-8 16.04A1.003 1.003 0 0 0 1 18h16c.347 0 .668-.18.85-.476a.998.998 0 0 0 .044-.975zM8 7.975V9.98a1 1 0 1 0 2 0V7.975a1 1 0 1 0-2 0m1.71 4.3c-.05-.04-.1-.09-.16-.12a.567.567 0 0 0-.17-.09.61.61 0 0 0-.19-.06.999.999 0 0 0-.9.27c-.09.101-.16.201-.21.33a1.01 1.01 0 0 0-.08.383c0 .26.11.52.29.711.19.18.44.291.71.291.06 0 .13-.01.19-.02a.635.635 0 0 0 .19-.06.59.59 0 0 0 .17-.09c.06-.04.11-.08.16-.12.18-.192.29-.452.29-.712 0-.132-.03-.261-.08-.382a.94.94 0 0 0-.21-.33"></path><path id="close-tiny" d="M7.426 6.001l4.278-4.279A1.008 1.008 0 1 0 10.278.296L6 4.574 1.723.296A1.008 1.008 0 1 0 .295 1.722l4.278 4.28-4.279 4.277a1.008 1.008 0 1 0 1.427 1.426L6 7.427l4.278 4.278a1.006 1.006 0 0 0 1.426 0 1.008 1.008 0 0 0 0-1.426L7.425 6.001z"></path><path id="close-small" d="M10.414 9l6.293-6.293a.999.999 0 1 0-1.414-1.414L9 7.586 2.707 1.293a.999.999 0 1 0-1.414 1.414L7.586 9l-6.293 6.293a.999.999 0 1 0 1.414 1.414L9 10.414l6.293 6.293a.997.997 0 0 0 1.414 0 .999.999 0 0 0 0-1.414L10.414 9z"></path><path id="pin-a" d="M12 14h4V3H8v11h4zm0 9a1 1 0 0 1-1-1v-6H4a1 1 0 1 1 0-2h2V3H4a1 1 0 1 1 0-2h16a1 1 0 1 1 0 2h-2v11h2a1 1 0 1 1 0 2h-7v6a1 1 0 0 1-1 1z"></path><path id="share-a" d="M19,22 C17.346,22 16,20.654 16,19 C16,18.552 16.099,18.126 16.276,17.744 C16.293,17.716 16.31,17.687 16.325,17.656 C16.339,17.628 16.352,17.6 16.363,17.57 C16.872,16.636 17.863,16 19,16 C20.654,16 22,17.346 22,19 C22,20.654 20.654,22 19,22 M7.724,13.256 C7.707,13.284 7.69,13.313 7.675,13.344 C7.661,13.372 7.648,13.4 7.637,13.43 C7.128,14.364 6.137,15 5,15 C3.346,15 2,13.654 2,12 C2,10.346 3.346,9 5,9 C6.137,9 7.128,9.636 7.637,10.57 C7.648,10.6 7.661,10.628 7.675,10.656 C7.69,10.687 7.707,10.716 7.724,10.744 C7.901,11.126 8,11.552 8,12 C8,12.448 7.901,12.874 7.724,13.256 M19,2 C20.654,2 22,3.346 22,5 C22,6.654 20.654,8 19,8 C17.863,8 16.872,7.364 16.363,6.43 C16.352,6.4 16.339,6.372 16.325,6.344 C16.31,6.313 16.293,6.284 16.276,6.256 C16.099,5.874 16,5.448 16,5 C16,3.346 17.346,2 19,2 M19,14 C17.407,14 15.986,14.749 15.069,15.912 L9.829,13.301 C9.94,12.885 10,12.449 10,12 C10,11.551 9.94,11.115 9.829,10.699 L15.069,8.088 C15.986,9.251 17.407,10 19,10 C21.757,10 24,7.757 24,5 C24,2.243 21.757,0 19,0 C16.243,0 14,2.243 14,5 C14,5.449 14.06,5.885 14.171,6.301 L8.931,8.912 C8.014,7.749 6.593,7 5,7 C2.243,7 0,9.243 0,12 C0,14.757 2.243,17 5,17 C6.593,17 8.014,16.251 8.931,15.088 L14.171,17.699 C14.06,18.115 14,18.551 14,19 C14,21.757 16.243,24 19,24 C21.757,24 24,21.757 24,19 C24,16.243 21.757,14 19,14"></path><path id="more-a" d="M12 18c-1.654 0-3 1.346-3 3s1.346 3 3 3 3-1.346 3-3-1.346-3-3-3m0-12c1.654 0 3-1.346 3-3s-1.346-3-3-3-3 1.346-3 3 1.346 3 3 3m0 3c-1.654 0-3 1.346-3 3s1.346 3 3 3 3-1.346 3-3-1.346-3-3-3"></path><path id="lock-a" d="M10 15h1v3a1 1 0 1 0 2 0v-3h1a1 1 0 1 0 0-2h-4a1 1 0 1 0 0 2m-5 7h14V10H5v12zM9 5c0-1.654 1.346-3 3-3s3 1.346 3 3v3H9V5zm11 3h-3V5c0-2.757-2.243-5-5-5S7 2.243 7 5v3H4a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1z"></path><path id="unlock-a" d="M10 15h1v3a1 1 0 1 0 2 0v-3h1a1 1 0 1 0 0-2h-4a1 1 0 1 0 0 2m-5 7h14V10H5v12zM20 8H9V5c0-1.654 1.346-3 3-3 .795 0 1.551.313 2.128.882a1 1 0 1 0 1.404-1.424A5.006 5.006 0 0 0 12 0C9.243 0 7 2.243 7 5v3H4a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1z"></path><path id="arrow-a" d="M23 11H3.414l7.293-7.293a.999.999 0 1 0-1.414-1.414l-9 9a.983.983 0 0 0-.293.704v.006a.988.988 0 0 0 .293.704l9 9a.997.997 0 0 0 1.414 0 .999.999 0 0 0 0-1.414L3.414 13H23a1 1 0 1 0 0-2"></path><path id="question-a" d="M12 22C6.486 22 2 17.514 2 12S6.486 2 12 2s10 4.486 10 10-4.486 10-10 10m0-22C5.383 0 0 5.383 0 12s5.383 12 12 12 12-5.383 12-12S18.617 0 12 0m0 5a4.007 4.007 0 0 0-3.771 2.666.998.998 0 1 0 1.884.668A2.001 2.001 0 0 1 14 9c0 1.104-.897 2-2 2a1 1 0 0 0-1 1v2a1 1 0 1 0 2 0v-1.127A4.006 4.006 0 0 0 16 9c0-2.205-1.794-4-4-4m-.005 11.99a1.01 1.01 0 0 0-1.006 1.005A1.01 1.01 0 0 0 11.995 19c.553 0 1.005-.453 1.005-1.005 0-.552-.452-1.005-1.005-1.005"></path><path id="close-a" d="M22.083 23a.914.914 0 0 1-.648-.269l-9.485-9.485-9.385 9.385a.917.917 0 0 1-1.296-1.297l9.384-9.384L1.37 2.666a.917.917 0 0 1 1.297-1.297l9.284 9.283 9.384-9.383a.916.916 0 1 1 1.297 1.296l-9.385 9.385 9.485 9.485A.916.916 0 0 1 22.083 23"></path><filter id="a" width="130%" height="130%" x="-15%" y="-15%" filterunits="objectBoundingBox"><feoffset in="SourceAlpha" result="shadowOffsetOuter1"></feoffset><fegaussianblur in="shadowOffsetOuter1" result="shadowBlurOuter1" stddeviation="7.5"></fegaussianblur><fecolormatrix in="shadowBlurOuter1" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"></fecolormatrix></filter><rect id="b" width="150" height="150" rx="75"></rect><path id="facebook-a" d="M16.762 5.432h-1.786c-1.428 0-1.666.71-1.666 1.657v2.248h3.452l-.357 3.55h-2.857V22H9.976v-9.112H7v-3.55h2.976V6.733C9.976 3.775 11.762 2 14.381 2c1.19 0 2.262.118 2.619.118v3.314h-.238z"></path><path id="twitter-a" d="M20.681 7.328v.577c0 5.915-4.486 12.695-12.735 12.695-2.605 0-4.92-.721-6.946-2.02.434 0 .724.145 1.158.145 2.026 0 4.052-.722 5.644-1.876-1.882 0-3.618-1.298-4.197-3.174.29 0 .579.145.868.145.434 0 .434 0 1.013-.145-2.17-.432-4.052-2.308-4.052-4.472 0 .433 1.592.433 2.316.577-1.158-.865-1.882-2.164-1.882-3.75 0-.866.29-1.587.724-2.309 2.17 2.741 5.644 4.472 9.261 4.761-.144-.433-.144-.721-.144-1.01C11.709 5.02 13.735 3 16.195 3c1.302 0 2.46.433 3.328 1.443 1.013-.289 1.882-.577 2.75-1.154-.434 1.154-1.158 1.875-1.881 2.452a13.73 13.73 0 0 0 2.604-.721c-.723.865-1.447 1.73-2.315 2.308z"></path><path id="reddit-a" d="M21.334 13.023c.359-.283.538-.671.538-1.166 0-.354-.112-.663-.342-.928a1.111 1.111 0 0 0-.882-.398 1.17 1.17 0 0 0-.734.268 5.004 5.004 0 0 1 1.42 2.224m-2.572-9.275a.97.97 0 0 0-.222.638c0 .247.076.458.222.635a.697.697 0 0 0 .562.265c.23 0 .426-.088.59-.265a.904.904 0 0 0 .244-.635.908.908 0 0 0-.244-.638.773.773 0 0 0-.59-.264.697.697 0 0 0-.562.264M14.156 15.09c.31.319.677.477 1.102.477.424 0 .793-.158 1.102-.477.311-.319.466-.724.466-1.219 0-.46-.146-.848-.44-1.167-.294-.316-.67-.476-1.128-.476-.458 0-.832.16-1.127.476-.295.32-.44.708-.44 1.167 0 .495.153.9.465 1.219m-2.18 4.716c1.568 0 2.84-.529 3.822-1.589l-.638-.635c-.815.848-1.878 1.27-3.184 1.27a4.38 4.38 0 0 1-1.666-.319c-.523-.21-.9-.422-1.128-.635l-.343-.316-.637.635c.98 1.06 2.237 1.59 3.774 1.59M7.221 13.87c0 .495.157.9.467 1.219.309.319.677.477 1.102.477a1.49 1.49 0 0 0 1.104-.477c.308-.319.463-.724.463-1.219 0-.46-.145-.848-.44-1.167-.293-.316-.67-.476-1.127-.476-.457 0-.832.16-1.128.476-.292.32-.44.708-.44 1.167m-4.556-.9c.262-.814.734-1.537 1.42-2.172a1.167 1.167 0 0 0-.734-.268c-.326 0-.613.133-.858.398a1.316 1.316 0 0 0-.367.928c0 .53.18.902.539 1.114M23 11.911c0 1.094-.44 1.89-1.324 2.383.034.179.05.425.05.744 0 2.013-.955 3.735-2.866 5.167-1.91 1.43-4.206 2.145-6.884 2.145s-4.965-.708-6.86-2.121c-1.896-1.412-2.843-3.125-2.843-5.14 0-.352.017-.616.05-.795C1.44 13.801 1 13.004 1 11.91c0-.74.245-1.37.733-1.88.492-.513 1.063-.77 1.717-.77.588 0 1.127.229 1.616.69C6.864 8.607 8.97 7.884 11.39 7.778h.096l1.52-5.459 4.409.952C17.87 2.423 18.509 2 19.324 2h.05c.621 0 1.135.231 1.543.69.408.459.613 1.024.613 1.696 0 .67-.205 1.236-.613 1.696a1.975 1.975 0 0 1-1.542.687h-.05c-.555 0-1.046-.203-1.47-.608a2.186 2.186 0 0 1-.686-1.51l-3.283-.743-1.078 3.921c2.484.177 4.524.885 6.126 2.121.488-.461 1.045-.69 1.665-.69.653 0 1.218.257 1.69.77.474.51.711 1.14.711 1.88"></path><path id="dropdown-tiny-a" d="M6.0001895,8.80004571 C5.79538755,8.80004571 5.5905856,8.72164496 5.43458411,8.56564348 L2.23455364,5.365613 C2.00575146,5.13681083 1.93695081,4.79280755 2.06095199,4.4936047 C2.18415316,4.19440185 2.47695595,4 2.80015903,4 L9.20021997,4 C9.52342305,4 9.81542583,4.19440185 9.93942701,4.4936047 C10.0634282,4.79280755 9.99462754,5.13681083 9.76582536,5.365613 L6.56579489,8.56564348 C6.4097934,8.72164496 6.20499145,8.80004571 6.0001895,8.80004571 Z"></path><path id="arrow-small" d="M8 17a.997.997 0 0 1-.707-.293l-7-7A.983.983 0 0 1 0 9.003v-.006a.988.988 0 0 1 .293-.704l7-7a.999.999 0 1 1 1.414 1.414L3.414 8H17a1 1 0 1 1 0 2H3.414l5.293 5.293A.999.999 0 0 1 8 17"></path><path id="user-avatar-a" d="M12 11c-.965 0-1.75-.785-1.75-1.75S11.035 7.5 12 7.5s1.75.785 1.75 1.75S12.965 11 12 11m0-5.5a3.754 3.754 0 0 0-3.75 3.75A3.754 3.754 0 0 0 12 13a3.754 3.754 0 0 0 3.75-3.75A3.754 3.754 0 0 0 12 5.5m7.679 12.914c-1.987-2.104-4.727-3.289-7.679-3.289-2.953 0-5.692 1.185-7.679 3.289A9.955 9.955 0 0 1 2 12C2 6.486 6.486 2 12 2s10 4.486 10 10a9.956 9.956 0 0 1-2.321 6.414M12 22a9.995 9.995 0 0 1-6.25-2.187c1.613-1.719 3.844-2.688 6.25-2.688s4.637.969 6.249 2.688A9.993 9.993 0 0 1 12 22m0-22C5.383 0 0 5.383 0 12c0 3.268 1.294 6.33 3.651 8.63l.012.013A12 12 0 0 0 12 24h.036a12.008 12.008 0 0 0 8.306-3.363C22.701 18.341 24 15.273 24 12c0-6.617-5.383-12-12-12"></path><path id="book-tiny" d="M3.5 3C2.673 3 2 3.673 2 4.5v2.338c.91-.434 2.09-.434 3 0V4.5c0-.397-.159-.785-.437-1.063A1.513 1.513 0 0 0 3.5 3m5 3.5c.537 0 1.045.121 1.5.338V4.5c0-.397-.159-.785-.437-1.063A1.502 1.502 0 0 0 7 4.5v2.338A3.473 3.473 0 0 1 8.5 6.5M11 11a1 1 0 0 1-1-1c0-.827-.673-1.5-1.5-1.5S7 9.173 7 10a1 1 0 1 1-2 0c0-.827-.673-1.5-1.5-1.5S2 9.173 2 10a1 1 0 1 1-2 0V4.5a3.504 3.504 0 0 1 5.977-2.477l.026.027A3.489 3.489 0 0 1 8.5 1c.937 0 1.817.363 2.477 1.023A3.524 3.524 0 0 1 12 4.5V10a1 1 0 0 1-1 1"></path><path id="share-small" d="M14.5 15a1.502 1.502 0 0 1-1.406-2.022l.022-.05.017-.045c.236-.52.76-.883 1.367-.883.827 0 1.5.673 1.5 1.5s-.673 1.5-1.5 1.5M4.906 9.522l-.022.05-.017.045c-.236.52-.76.883-1.367.883C2.673 10.5 2 9.827 2 9s.673-1.5 1.5-1.5c.607 0 1.131.363 1.367.883l.017.045.022.05a1.482 1.482 0 0 1 0 1.044M14.5 3c.827 0 1.5.673 1.5 1.5S15.327 6 14.5 6a1.503 1.503 0 0 1-1.367-.883l-.017-.045-.022-.05A1.502 1.502 0 0 1 14.5 3m0 7c-1.098 0-2.08.508-2.722 1.303L6.983 9.348a3.653 3.653 0 0 0 0-.696l4.795-1.955A3.492 3.492 0 0 0 14.5 8C16.43 8 18 6.43 18 4.5S16.43 1 14.5 1a3.504 3.504 0 0 0-3.483 3.848L6.222 6.803A3.492 3.492 0 0 0 3.5 5.5C1.57 5.5 0 7.07 0 9s1.57 3.5 3.5 3.5c1.098 0 2.08-.508 2.722-1.303l4.795 1.955A3.504 3.504 0 0 0 14.5 17c1.93 0 3.5-1.57 3.5-3.5S16.43 10 14.5 10"></path><path id="pencil-small" d="M14 8.586L9.414 4 11 2.414 15.586 7 14 8.586zM6.586 16H2v-4.586l6-6L12.586 10l-6 6zm11.121-9.707l-6-6a.999.999 0 0 0-1.414 0l-9.999 10a.99.99 0 0 0-.217.325A.991.991 0 0 0 0 11v6a1 1 0 0 0 1 1h6c.13 0 .26-.026.382-.077a.99.99 0 0 0 .326-.217l9.999-9.999a.999.999 0 0 0 0-1.414z"></path><rect id="path-1" x=".667" y="0" width="78" height="78" rx="6"></rect><lineargradient id="store-googleplay-gradient-1" x1="91.536%" x2="-37.559%" y1="4.839%" y2="71.968%"><stop stop-color="#00A0FF" offset="0%"></stop><stop stop-color="#00A1FF" offset=".657%"></stop><stop stop-color="#00BEFF" offset="26.01%"></stop><stop stop-color="#00D2FF" offset="51.22%"></stop><stop stop-color="#00DFFF" offset="76.04%"></stop><stop stop-color="#00E3FF" offset="100%"></stop></lineargradient><lineargradient id="store-googleplay-gradient-2" x1="107.728%" x2="-130.665%" y1="49.428%" y2="49.428%"><stop stop-color="#FFE000" offset="0%"></stop><stop stop-color="#FFBD00" offset="40.87%"></stop><stop stop-color="orange" offset="77.54%"></stop><stop stop-color="#FF9C00" offset="100%"></stop></lineargradient><lineargradient id="store-googleplay-gradient-3" x1="86.389%" x2="-49.888%" y1="17.815%" y2="194.393%"><stop stop-color="#FF3A44" offset="0%"></stop><stop stop-color="#C31162" offset="100%"></stop></lineargradient><lineargradient id="store-googleplay-gradient-4" x1="-18.579%" x2="42.275%" y1="-54.527%" y2="24.69%"><stop stop-color="#32A071" offset="0%"></stop><stop stop-color="#2DA771" offset="6.85%"></stop><stop stop-color="#15CF74" offset="47.62%"></stop><stop stop-color="#06E775" offset="80.09%"></stop><stop stop-color="#00F076" offset="100%"></stop></lineargradient><rect id="path-1" x=".222" y=".111" width="78" height="78" rx="6"></rect></defs><symbol id="wds-icons-pencil-tiny" viewbox="0 0 12 12"><use fill-rule="evenodd" xlink:href="#pencil-tiny"></use></symbol><symbol id="wds-company-logo-fandom" viewbox="0 0 164 35"><g fill="none" fill-rule="evenodd"><path d="M32.003 16.524c0 .288-.115.564-.32.768L18.3 30.712c-.226.224-.454.324-.738.324-.292 0-.55-.11-.77-.325l-.943-.886a.41.41 0 0 1-.01-.59l15.45-15.46c.262-.263.716-.078.716.29v2.46zm-17.167 10.12l-.766.685a.642.642 0 0 1-.872-.02L3.01 17.362c-.257-.25-.4-.593-.4-.95v-1.858c0-.67.816-1.007 1.298-.536l10.814 10.56c.188.187.505.57.505 1.033 0 .296-.068.715-.39 1.035zM5.73 7.395L9.236 3.93a.421.421 0 0 1 .592 0l11.736 11.603a3.158 3.158 0 0 1 0 4.5l-3.503 3.462a.423.423 0 0 1-.59 0L5.732 11.89a3.132 3.132 0 0 1-.937-2.25c0-.85.332-1.65.935-2.246zm13.89 1.982l3.662-3.62a3.232 3.232 0 0 1 2.737-.897c.722.098 1.378.47 1.893.978l3.708 3.667a.41.41 0 0 1 0 .585l-5.64 5.576a.419.419 0 0 1-.59 0l-5.77-5.704a.411.411 0 0 1 0-.585zm14.56-.687L26.014.475a.869.869 0 0 0-1.228-.002L18.307 6.94c-.5.5-1.316.5-1.82.004l-6.48-6.4A.87.87 0 0 0 8.793.542L.447 8.67C.16 8.95 0 9.33 0 9.727v7.7c0 .392.158.77.44 1.048l16.263 16.072a.87.87 0 0 0 1.22 0l16.25-16.073c.28-.278.438-.655.438-1.048V9.73c0-.39-.153-.763-.43-1.04z" fill="#00D6D6"></path><path d="M62.852 20.51l2.58-6.716a.468.468 0 0 1 .87 0l2.58 6.717h-6.03zm5.856-12.428c-.184-.48-.65-.8-1.17-.8h-3.342c-.52 0-.986.32-1.17.8l-7.083 18.5c-.21.552.2 1.14.796 1.14h2.753c.353 0 .67-.215.796-.542l.738-1.922a.849.849 0 0 1 .795-.542h8.088a.85.85 0 0 1 .796.542l.74 1.922c.125.327.44.543.795.543h2.754a.843.843 0 0 0 .796-1.14l-7.082-18.5zm93.504-.8h-2.715a1.86 1.86 0 0 0-1.677 1.047l-5.393 11.162-5.393-11.163a1.858 1.858 0 0 0-1.677-1.047h-2.715a.889.889 0 0 0-.893.883V26.84c0 .487.4.883.892.883h2.608a.889.889 0 0 0 .893-.883v-9.686l4.945 10.072c.15.304.46.497.803.497h1.073a.893.893 0 0 0 .803-.497l4.945-10.072v9.686c0 .487.4.883.894.883h2.608a.889.889 0 0 0 .893-.883V8.166c0-.487-.4-.883-.893-.883zm-106.972 8.8h-8.63V11.49h10.918a.88.88 0 0 0 .83-.578l.888-2.464a.872.872 0 0 0-.83-1.163h-15.18c-.486 0-.88.39-.88.87v18.7c0 .48.394.87.88.87h2.492c.486 0 .88-.39.88-.87V20.29h7.743a.88.88 0 0 0 .83-.578l.89-2.464a.872.872 0 0 0-.83-1.163zm51.76 7.61h-3.615V11.315H107c3.828 0 6.41 2.517 6.41 6.188 0 3.672-2.582 6.19-6.41 6.19zm-.124-16.41h-7.128c-.486 0-.88.39-.88.872v18.698c0 .48.394.87.88.87h7.128c6.453 0 10.912-4.44 10.912-10.16v-.117c0-5.72-4.46-10.162-10.912-10.162zm-11.947.03h-2.642a.87.87 0 0 0-.876.866v12.36l-8.755-12.72a1.242 1.242 0 0 0-1.023-.535H78.32a.873.873 0 0 0-.876.867v18.706c0 .48.393.867.877.867h2.64a.872.872 0 0 0 .878-.867V14.71l8.608 12.478c.23.334.613.535 1.022.535h3.46a.872.872 0 0 0 .877-.867V8.178a.87.87 0 0 0-.876-.867zm40.71 10.3c0 3.323-2.712 6.016-6.056 6.016-3.345 0-6.056-2.693-6.056-6.015v-.22c0-3.322 2.71-6.015 6.056-6.015 3.344 0 6.055 2.693 6.055 6.015v.22zm-6.056-10.44c-5.694 0-10.31 4.576-10.31 10.22v.22c0 5.646 4.616 10.22 10.31 10.22 5.693 0 10.308-4.574 10.308-10.22v-.22c0-5.644-4.615-10.22-10.308-10.22z" fill="#002A32"></path></g></symbol><symbol id="wds-icons-trash-tiny" viewbox="0 0 12 12"><use fill-rule="evenodd" xlink:href="#trash-tiny"></use></symbol><symbol id="wds-icons-flag-small" viewbox="0 0 18 18"><use fill-rule="evenodd" xlink:href="#flag-small"></use></symbol><symbol id="wds-icons-checkmark-small" viewbox="0 0 18 18"><path d="M6 16a.997.997 0 0 1-.707-.293l-5-5a.999.999 0 1 1 1.414-1.414L6 13.586 16.293 3.293a.999.999 0 1 1 1.414 1.414l-11 11A.997.997 0 0 1 6 16" fill-rule="evenodd"></path></symbol><symbol id="wds-icons-error-small" viewbox="0 0 18 18"><path fill-rule="evenodd" d="M11.0487656,5.33462857 C11.494971,4.88845714 12.2191405,4.88845714 12.6653459,5.33462857 C13.1115514,5.7808 13.1115514,6.50491429 12.6653459,6.95108571 L10.6171899,9.00030476 L12.6653459,11.0483048 C13.1115514,11.4956952 13.1115514,12.2185905 12.6653459,12.665981 C12.4422432,12.8878476 12.1496495,13 11.8570558,13 C11.5644621,13 11.2718683,12.8878476 11.0487656,12.665981 L8.99939043,10.6167619 L6.95123438,12.665981 C6.72813167,12.8878476 6.43431881,13 6.14294422,13 C5.8503505,13 5.55775678,12.8878476 5.33465407,12.665981 C4.88844864,12.2185905 4.88844864,11.4956952 5.33465407,11.0483048 L7.38281012,9.00030476 L5.33465407,6.95108571 C4.88844864,6.50491429 4.88844864,5.7808 5.33465407,5.33462857 C5.78085949,4.88845714 6.50380981,4.88845714 6.95123438,5.33462857 L8.99939043,7.38384762 L11.0487656,5.33462857 Z M16,11.8986667 L16,6.10026667 L11.8997333,2 L6.10026667,2 L2,6.10026667 L2,11.8986667 L6.10026667,16 L11.8997333,16 L16,11.8986667 Z M17.7077333,4.9792 C17.8944,5.16586667 18,5.4208 18,5.6864 L18,12.3136 C18,12.5792 17.8944,12.8330667 17.7077333,13.0208 L13.0208,17.7066667 C12.8330667,17.8944 12.5781333,18 12.3136,18 L5.6864,18 C5.42186667,18 5.16693333,17.8944 4.9792,17.7066667 L0.292266667,13.0208 C0.1056,12.8330667 0,12.5792 0,12.3136 L0,5.6864 C0,5.4208 0.1056,5.16586667 0.292266667,4.9792 L4.9792,0.292266667 C5.16693333,0.104533333 5.42186667,0 5.6864,0 L12.3136,0 C12.5781333,0 12.8330667,0.104533333 13.0208,0.292266667 L17.7077333,4.9792 Z"></path></symbol><symbol id="wds-icons-alert-small" viewbox="0 0 18 18"><use fill-rule="evenodd" xlink:href="#alert-small"></use></symbol><symbol id="wds-icons-close-tiny" viewbox="0 0 12 12"><use fill-rule="evenodd" xlink:href="#close-tiny"></use></symbol><symbol id="wds-icons-close-small" viewbox="0 0 18 18"><use fill-rule="evenodd" xlink:href="#close-small"></use></symbol><symbol id="wds-icons-info-small" viewbox="0 0 18 18"><path clip-rule="evenodd" d="M9 16C5.141 16 2 12.859 2 9C2 5.141 5.141 2 9 2C12.859 2 16 5.141 16 9C16 12.859 12.859 16 9 16M9 0C4.037 0 0 4.037 0 9C0 13.963 4.037 18 9 18C13.963 18 18 13.963 18 9C18 4.037 13.963 0 9 0"></path><path clip-rule="evenodd" d="M8 12.9975V8.00982C8 7.45545 8.447 7.00735 9 7.00735 9.553 7.00735 10 7.45545 10 8.00982V12.9975C10 13.5519 9.553 14 9 14 8.447 14 8 13.5519 8 12.9975zM9.71 5.71419C9.66 5.75429 9.609 5.80541 9.55 5.83449 9.5 5.87459 9.439 5.90466 9.38 5.92471 9.319 5.95478 9.26 5.97584 9.189 5.98586 8.87 6.05603 8.52 5.94376 8.29 5.71419 8.2 5.61394 8.13 5.51369 8.08 5.38437 8.03 5.26307 8 5.13375 8 5.00243 8 4.74178 8.109 4.48214 8.29 4.29067 8.48 4.11022 8.73 3.99995 9 3.99995 9.06 3.99995 9.13 4.00998 9.189 4.02 9.26 4.03003 9.319 4.05108 9.38 4.08015 9.439 4.1002 9.5 4.13128 9.55 4.17037 9.609 4.21047 9.66 4.25057 9.71 4.29067 9.89 4.48214 10 4.74178 10 5.00243 10 5.13375 9.97 5.26307 9.92 5.38437 9.87 5.51369 9.8 5.62397 9.71 5.71419"></path></symbol><symbol id="wds-company-logo-fandom-heart" viewbox="0 0 35 35"><path d="M32.003 16.524c0 .288-.115.564-.32.768L18.3 30.712c-.226.224-.454.324-.738.324-.292 0-.55-.11-.77-.325l-.943-.886a.41.41 0 0 1-.01-.59l15.45-15.46c.262-.263.716-.078.716.29v2.46zm-17.167 10.12l-.766.685a.642.642 0 0 1-.872-.02L3.01 17.362c-.257-.25-.4-.593-.4-.95v-1.858c0-.67.816-1.007 1.298-.536l10.814 10.56c.188.187.505.57.505 1.033 0 .296-.068.715-.39 1.035zM5.73 7.395L9.236 3.93a.421.421 0 0 1 .592 0l11.736 11.603a3.158 3.158 0 0 1 0 4.5l-3.503 3.462a.423.423 0 0 1-.59 0L5.732 11.89a3.132 3.132 0 0 1-.937-2.25c0-.85.332-1.65.935-2.246zm13.89 1.982l3.662-3.62a3.232 3.232 0 0 1 2.737-.897c.722.098 1.378.47 1.893.978l3.708 3.667a.41.41 0 0 1 0 .585l-5.64 5.576a.419.419 0 0 1-.59 0l-5.77-5.704a.411.411 0 0 1 0-.585zm14.56-.687L26.014.475a.869.869 0 0 0-1.228-.002L18.307 6.94c-.5.5-1.316.5-1.82.004l-6.48-6.4A.87.87 0 0 0 8.793.542L.447 8.67C.16 8.95 0 9.33 0 9.727v7.7c0 .392.158.77.44 1.048l16.263 16.072a.87.87 0 0 0 1.22 0l16.25-16.073c.28-.278.438-.655.438-1.048V9.73c0-.39-.153-.763-.43-1.04z" fill="#00D6D6" fill-rule="evenodd"></path></symbol><symbol id="wds-icons-pin" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#pin-a"></use></symbol><symbol id="wds-icons-share" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#share-a"></use></symbol><symbol id="wds-icons-more" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#more-a"></use></symbol><symbol id="wds-icons-lock" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#lock-a"></use></symbol><symbol id="wds-icons-unlock" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#unlock-a"></use></symbol><symbol id="wds-icons-arrow" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#arrow-a"></use></symbol><symbol id="wds-icons-question" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#question-a"></use></symbol><symbol id="wds-icons-close" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#close-a"></use></symbol><symbol id="wds-player-icon-play" viewbox="0 0 180 180"><g fill="none" fill-rule="evenodd"><g opacity=".9" transform="rotate(90 75 90)"><use fill="#000" filter="url(#a)" xlink:href="#b"></use><use fill="#FFF" xlink:href="#b"></use></g><path fill="#00D6D6" fill-rule="nonzero" d="M80.87 58.006l34.32 25.523c3.052 2.27 3.722 6.633 1.496 9.746a6.91 6.91 0 0 1-1.497 1.527l-34.32 25.523c-3.053 2.27-7.33 1.586-9.558-1.527A7.07 7.07 0 0 1 70 114.69V63.643c0-3.854 3.063-6.977 6.84-6.977 1.45 0 2.86.47 4.03 1.34z"></path></g></symbol><symbol id="wds-icons-line" viewbox="0 0 24 24"><path d="M21.727 10.908c0-4.37-4.428-7.925-9.87-7.925-5.441 0-9.869 3.555-9.869 7.925 0 3.918 3.511 7.2 8.254 7.82.321.068.759.21.87.481.1.247.065.633.031.883l-.14.836c-.043.247-.199.966.855.527 1.053-.44 5.683-3.312 7.753-5.67 1.43-1.553 2.116-3.128 2.116-4.877zm-13.732 2.6H6.033a.515.515 0 0 1-.517-.512V9.115c0-.282.232-.512.517-.512.286 0 .518.23.518.512v3.369h1.444c.285 0 .517.23.517.512a.515.515 0 0 1-.517.512zm2.028-.512a.515.515 0 0 1-.518.512.515.515 0 0 1-.517-.512V9.115c0-.282.232-.512.517-.512.286 0 .518.23.518.512v3.88zm4.72 0a.51.51 0 0 1-.518.512.523.523 0 0 1-.414-.205l-2.01-2.708v2.4a.515.515 0 0 1-.517.513.515.515 0 0 1-.517-.512V9.115a.512.512 0 0 1 .518-.512.52.52 0 0 1 .413.205l2.01 2.708V9.115c0-.282.232-.512.518-.512.285 0 .517.23.517.512v3.88zm3.173-2.453c.285 0 .518.23.518.513a.516.516 0 0 1-.518.512h-1.443v.916h1.443c.285 0 .518.23.518.512a.516.516 0 0 1-.518.512h-1.961a.516.516 0 0 1-.517-.512V9.115c0-.282.232-.512.517-.512h1.961c.285 0 .518.23.518.512a.515.515 0 0 1-.518.512h-1.443v.916h1.443z"></path></symbol><symbol id="wds-icons-vkontakte" viewbox="0 0 24 24"><path d="M8.169 7.816a1.17 1.17 0 0 1 .792-.65 5.11 5.11 0 0 1 1.037-.175 27.89 27.89 0 0 1 1.925-.025c.329.006.662.048.984.117.591.126.88.45.924 1.062.03.439.013.882-.003 1.322-.018.462-.064.924-.089 1.386a13.41 13.41 0 0 0-.024.981c.007.384.044.77.285 1.09.233.31.279.34.621.132.189-.115.348-.294.487-.472.964-1.23 1.699-2.59 2.26-4.052.054-.138.124-.27.179-.407.182-.446.528-.631.983-.633.414-.001.829.022 1.244.024.62.002 1.24-.012 1.861-.004.267.005.538.024.797.082.353.078.477.305.41.666-.094.508-.315.965-.567 1.407-.464.812-1.043 1.54-1.612 2.275a68.25 68.25 0 0 0-1.066 1.42 1.933 1.933 0 0 0-.191.345c-.229.504-.158.905.252 1.32.419.422.855.828 1.276 1.248.62.62 1.19 1.284 1.655 2.031.117.187.205.402.259.615.068.273-.05.5-.278.658-.265.187-.575.248-.884.251-.645.008-1.292-.013-1.937-.02-.326-.004-.653-.011-.976.067-.09.023-.2-.01-.296-.033-.618-.148-1.127-.489-1.587-.916-.454-.422-.833-.91-1.221-1.39-.14-.173-.3-.334-.478-.466a.989.989 0 0 0-.443-.189c-.321-.046-.577.107-.678.423-.083.263-.116.543-.155.82-.036.272-.037.55-.077.824-.075.517-.227.743-.878.859-.536.094-1.072.047-1.607-.001-.74-.069-1.468-.207-2.166-.472-1.063-.401-1.96-1.049-2.739-1.874-.822-.873-1.521-1.845-2.186-2.841-1-1.5-1.835-3.091-2.607-4.719-.217-.458-.452-.91-.565-1.41-.04-.178-.06-.36-.091-.539-.018-.107.016-.19.115-.223.21-.069.421-.17.634-.18.528-.026 1.057-.006 1.586-.01.44-.004.88-.019 1.319-.022.1-.001.2.02.3.034a.732.732 0 0 1 .572.41c.124.25.254.497.363.754a20.133 20.133 0 0 0 1.94 3.517c.16.233.32.47.503.684.1.118.237.217.376.285.23.113.435.048.54-.184a2.32 2.32 0 0 0 .204-.662c.13-.972.145-1.95.053-2.925a4.61 4.61 0 0 0-.126-.662c-.077-.312-.278-.525-.568-.652a38.53 38.53 0 0 1-.494-.222c-.05-.021-.095-.051-.147-.08"></path></symbol><symbol id="wds-icons-facebook" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#facebook-a"></use></symbol><symbol id="wds-icons-odnoklassniki" viewbox="0 0 24 24"><path d="M14.289 16.068c.33.319.618.598.909.875.644.613 1.296 1.22 1.934 1.84.67.65.694 1.557.071 2.176-.629.624-1.624.635-2.294-.01-.934-.9-1.844-1.823-2.794-2.764-.16.145-.26.23-.353.32-.812.778-1.625 1.554-2.432 2.337-.39.378-.837.626-1.408.576-.645-.056-1.113-.372-1.354-.953-.248-.598-.13-1.153.33-1.61.673-.672 1.372-1.318 2.061-1.974.267-.254.538-.503.863-.806-.214-.065-.356-.095-.486-.15-.806-.334-1.635-.629-2.407-1.024-.876-.449-1.114-1.383-.634-2.14.466-.734 1.412-.933 2.247-.475 2.342 1.285 4.684 1.284 7.025-.006.828-.456 1.78-.247 2.243.49.468.747.235 1.677-.618 2.116-.772.398-1.598.697-2.403 1.034-.135.057-.283.085-.5.148zM6.695 7.176c.01-2.858 2.419-5.131 5.422-5.118 2.925.013 5.31 2.344 5.29 5.171-.021 2.865-2.414 5.103-5.441 5.089-2.913-.013-5.282-2.325-5.271-5.142zm5.364-2.03c-1.191-.003-2.158.901-2.175 2.035-.017 1.114 1.009 2.1 2.177 2.093 1.164-.009 2.148-.957 2.154-2.077.005-1.123-.967-2.048-2.156-2.051z"></path></symbol><symbol id="wds-icons-twitter" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#twitter-a"></use></symbol><symbol id="wds-icons-meneame" viewbox="0 0 24 24"><path d="M20.494 7.792c-1.427 1.37-4.004 1.33-4.962 3.181-.818 2.195 1.107 5.702 1.911 7.702.545 1.033-4.253 2.03-3.666 2.285 3.385-.036 4.83-1.206 4.423-2.641-.389-1.373-2.144-4.114-2.144-6.305.05-1.654 2.004-2.162 3.263-2.836 1.463-.62 2.831-2.006 2.453-3.63-.016-.574-1.07-2.482-.64-1.003.235 1.092.347 2.44-.638 3.247"></path><path d="M16.091 5.326c-1.842-.9-3.89-1.444-6.032-.97-1.151.201-2.507.797-3.279 1.794-1.011 1.144-1.05 2.807-.387 4.115.515 1.007 1.299 2.128 2.569 2.296 1.092.155 2.292.015 3.22-.582-1.103.18-2.381.55-3.372-.147-1.66-1.005-2.467-3.287-1.46-4.952.81-1.452 2.441-1.86 4.167-1.932 2.301-.096 4.507 1.147 5.353 1.45.815.242 1.985.55 2.565-.27.339-.38.203-1.429-.072-1.526.08.735-.49 1.659-1.376 1.418-.662-.148-1.27-.449-1.896-.694M3.742 11.824c-1.067 1.592-2.042 3.457-1.67 5.398.342 2.03 2.416 3.46 4.478 3.715 2.117.234 4.23.174 6.352.03.358-.328-1.732-.319-2.612-.439-2.008-.215-4.186-.255-5.907-1.383-1.604-1.136-1.814-3.365-1.045-5.007.644-1.55 1.607-3.048 2.619-4.343-.79.621-1.519 1.084-2.215 2.029"></path><path d="M9.014 16.833c1.251.091 3.326-.029 4.301.616.35.497-.3 3.247-.076 3.564.498.139 1.067-3.222.752-4.057-.239-.637-4.479-.298-4.977-.123"></path></symbol><symbol id="wds-icons-reddit" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#reddit-a"></use></symbol><symbol id="wds-icons-tumblr" viewbox="0 0 24 24"><path d="M13.987 20.999c-3.79.067-5.226-2.794-5.226-4.807V10.31H7V7.985c2.64-.984 3.275-3.447 3.423-4.85.01-.097.083-.135.126-.135h2.549v4.585h3.48v2.725h-3.494v5.603c.013.763.282 1.814 1.675 1.775.461-.012 1.08-.152 1.403-.31L17 19.944c-.315.477-1.734 1.03-3.013 1.054"></path></symbol><symbol id="wds-icons-weibo" viewbox="0 0 24 24"><path d="M16.562 11.618c-.273-.081-.46-.137-.318-.493.31-.775.342-1.443.006-1.92-.63-.894-2.353-.845-4.328-.024 0 0-.62.27-.461-.219.303-.97.258-1.783-.215-2.253-1.072-1.065-3.921.04-6.365 2.468-1.83 1.819-2.893 3.746-2.893 5.413 0 3.188 4.115 5.126 8.14 5.126 5.275 0 8.785-3.047 8.785-5.465 0-1.46-1.238-2.29-2.351-2.633m-6.424 6.955c-3.211.315-5.984-1.127-6.192-3.223-.209-2.095 2.226-4.049 5.437-4.364 3.212-.316 5.985 1.127 6.193 3.221.208 2.096-2.226 4.05-5.438 4.366m9.927-12.789a5.155 5.155 0 0 0-4.888-1.572.738.738 0 1 0 .31 1.444c1.234-.26 2.57.12 3.476 1.117a3.611 3.611 0 0 1 .763 3.55.744.744 0 0 0 1.414.455v-.003a5.076 5.076 0 0 0-1.075-4.991"></path><path d="M18.109 7.539a2.51 2.51 0 0 0-2.381-.765.635.635 0 1 0 .266 1.242 1.23 1.23 0 0 1 1.165.374c.303.334.385.79.255 1.19a.635.635 0 0 0 .411.8.64.64 0 0 0 .805-.41 2.47 2.47 0 0 0-.521-2.431m-7.649 5.059c-1.53-.395-3.257.362-3.92 1.7-.676 1.365-.023 2.88 1.521 3.375 1.6.513 3.485-.273 4.14-1.746.647-1.44-.16-2.922-1.742-3.329m-1.167 3.486c-.31.492-.976.708-1.477.48-.494-.223-.64-.795-.329-1.275.307-.478.95-.691 1.447-.484.503.213.664.781.359 1.279m1.023-1.306c-.112.191-.36.283-.555.204-.191-.079-.251-.292-.142-.48.112-.186.35-.277.541-.202.194.07.264.286.156.478"></path></symbol><symbol id="wds-icons-nk" viewbox="0 0 24 24"><path d="M3.852 9.339c.573-.25 1.12-.505 1.68-.727 1.016-.403 2.066-.691 3.17-.714.331-.007.675.04.994.126.992.271 1.496.99 1.602 1.93.082.723.044 1.467-.01 2.197-.118 1.585-.278 3.167-.423 4.75-.09.976-.185 1.952-.268 2.93-.015.173-.082.236-.258.235-.877-.005-1.755-.008-2.632.002-.245.003-.275-.114-.256-.305.083-.86.161-1.718.24-2.577l.37-3.989c.047-.515.086-1.031.142-1.546.077-.7-.21-.987-.932-.911-.7.073-1.332.336-1.947.65-.421.214-.845.426-1.254.662a.467.467 0 0 0-.207.308c-.121 1.165-.226 2.332-.333 3.499-.12 1.293-.242 2.586-.352 3.88-.022.248-.115.337-.38.332-.803-.017-1.605-.006-2.408-.006-.356 0-.366-.002-.337-.337.14-1.61.285-3.22.428-4.83.119-1.34.24-2.678.354-4.017.032-.382.02-.383-.365-.385-.49-.003-.483-.002-.436-.478.053-.533.1-1.067.13-1.602.011-.22.091-.303.32-.299.578.011 1.157.003 1.735.004.982 0 1.362.28 1.633 1.218m9.826-3.941h-.861c0-.182-.012-.342.002-.5.049-.552.113-1.101.158-1.653.014-.176.089-.229.263-.228.83.007 1.661-.006 2.491.008.677.01 1.26.625 1.206 1.281-.12 1.455-.26 2.909-.389 4.363-.1 1.13-.193 2.26-.295 3.388-.103 1.138-.217 2.275-.32 3.413-.103 1.13-.196 2.26-.296 3.388-.031.353-.062.705-.113 1.055-.01.07-.112.181-.172.182-.97.01-1.94.004-2.91 0-.025 0-.05-.021-.113-.05l1.349-14.647m9.079 14.69c-.148.008-.238.017-.328.017-.905.001-1.81-.004-2.716.004-.2.002-.319-.054-.416-.236a942.803 942.803 0 0 0-3.025-5.618c-.08-.149-.078-.255.014-.395 1.215-1.842 2.422-3.687 3.64-5.527.06-.09.197-.182.3-.183 1.138-.013 2.276-.008 3.415-.007.044 0 .089.01.177.022-.072.112-.125.202-.186.287-1.297 1.799-2.592 3.599-3.897 5.393-.125.172-.137.296-.035.485.969 1.8 1.926 3.607 2.886 5.412.051.096.096.194.171.346"></path></symbol><symbol id="wds-icons-wykop" viewbox="0 0 24 24"><path d="M6.76 20.985a9.543 9.543 0 0 1-2.192-.45c-2.005-.646-2.991-2.095-3.251-3.988a34.21 34.21 0 0 1-.081-8.58c.308-2.687 2.073-4.3 4.983-4.635 3.068-.353 6.147-.287 9.223-.17a19.45 19.45 0 0 1 3.321.41c2.425.52 3.734 2.024 3.981 4.351.26 2.447.35 4.898.157 7.35-.093 1.183-.247 2.37-.935 3.412-.927 1.405-2.37 2.057-4.039 2.22-1.942.19-9.402.211-11.167.08zm7.421-2.064c1.314-.076 2.63-.154 3.933-.313.836-.102 1.547-.53 1.87-1.295.262-.622.516-1.291.548-1.95.093-1.902.101-3.81.08-5.715-.008-.658-.153-1.325-.322-1.967-.314-1.19-1.13-1.917-2.448-2.077-.743-.09-1.491-.189-2.24-.202a175.972 175.972 0 0 0-5.531-.018c-1.19.016-2.381.071-3.565.176-1.546.136-2.424.863-2.808 2.222a5.68 5.68 0 0 0-.126.546c-.345 1.919-.274 3.854-.204 5.784.028.78.155 1.565.317 2.333.23 1.096.928 1.842 2.101 2.132.41.101.833.182 1.253.203 1.656.083 6.422.182 7.142.14zm.995-12.884L12.6 7.227l3.196 6.103-1.269.6-3.248-6.091L8.66 9.048l3.204 6.117-1.269.6L7.34 9.66l-2.563 1.184 3.87 7.369 10.368-4.835-3.838-7.34"></path></symbol><symbol id="wds-company-logo-fandom-white" viewbox="0 0 164 35"><g fill="none" fill-rule="evenodd"><path d="M32.003 16.524c0 .288-.115.564-.32.768L18.3 30.712c-.226.224-.454.324-.738.324-.292 0-.55-.11-.77-.325l-.943-.886a.41.41 0 0 1-.01-.59l15.45-15.46c.262-.263.716-.078.716.29v2.46zm-17.167 10.12l-.766.685a.642.642 0 0 1-.872-.02L3.01 17.362c-.257-.25-.4-.593-.4-.95v-1.858c0-.67.816-1.007 1.298-.536l10.814 10.56c.188.187.505.57.505 1.033 0 .296-.068.715-.39 1.035zM5.73 7.395L9.236 3.93a.421.421 0 0 1 .592 0l11.736 11.603a3.158 3.158 0 0 1 0 4.5l-3.503 3.462a.423.423 0 0 1-.59 0L5.732 11.89a3.132 3.132 0 0 1-.937-2.25c0-.85.332-1.65.935-2.246zm13.89 1.982l3.662-3.62a3.232 3.232 0 0 1 2.737-.897c.722.098 1.378.47 1.893.978l3.708 3.667a.41.41 0 0 1 0 .585l-5.64 5.576a.419.419 0 0 1-.59 0l-5.77-5.704a.411.411 0 0 1 0-.585zm14.56-.687L26.014.475a.869.869 0 0 0-1.228-.002L18.307 6.94c-.5.5-1.316.5-1.82.004l-6.48-6.4A.87.87 0 0 0 8.793.542L.447 8.67C.16 8.95 0 9.33 0 9.727v7.7c0 .392.158.77.44 1.048l16.263 16.072a.87.87 0 0 0 1.22 0l16.25-16.073c.28-.278.438-.655.438-1.048V9.73c0-.39-.153-.763-.43-1.04z" fill="#00D6D6"></path><path d="M62.852 20.51l2.58-6.716a.468.468 0 0 1 .87 0l2.58 6.717h-6.03zm5.856-12.428c-.184-.48-.65-.8-1.17-.8h-3.342c-.52 0-.986.32-1.17.8l-7.083 18.5c-.21.552.2 1.14.796 1.14h2.753c.353 0 .67-.215.796-.542l.738-1.922a.849.849 0 0 1 .795-.542h8.088a.85.85 0 0 1 .796.542l.74 1.922c.125.327.44.543.795.543h2.754a.843.843 0 0 0 .796-1.14l-7.082-18.5zm93.504-.8h-2.715a1.86 1.86 0 0 0-1.677 1.047l-5.393 11.162-5.393-11.163a1.858 1.858 0 0 0-1.677-1.047h-2.715a.889.889 0 0 0-.893.883V26.84c0 .487.4.883.892.883h2.608a.889.889 0 0 0 .893-.883v-9.686l4.945 10.072c.15.304.46.497.803.497h1.073a.893.893 0 0 0 .803-.497l4.945-10.072v9.686c0 .487.4.883.894.883h2.608a.889.889 0 0 0 .893-.883V8.166c0-.487-.4-.883-.893-.883zm-106.972 8.8h-8.63V11.49h10.918a.88.88 0 0 0 .83-.578l.888-2.464a.872.872 0 0 0-.83-1.163h-15.18c-.486 0-.88.39-.88.87v18.7c0 .48.394.87.88.87h2.492c.486 0 .88-.39.88-.87V20.29h7.743a.88.88 0 0 0 .83-.578l.89-2.464a.872.872 0 0 0-.83-1.163zm51.76 7.61h-3.615V11.315H107c3.828 0 6.41 2.517 6.41 6.188 0 3.672-2.582 6.19-6.41 6.19zm-.124-16.41h-7.128c-.486 0-.88.39-.88.872v18.698c0 .48.394.87.88.87h7.128c6.453 0 10.912-4.44 10.912-10.16v-.117c0-5.72-4.46-10.162-10.912-10.162zm-11.947.03h-2.642a.87.87 0 0 0-.876.866v12.36l-8.755-12.72a1.242 1.242 0 0 0-1.023-.535H78.32a.873.873 0 0 0-.876.867v18.706c0 .48.393.867.877.867h2.64a.872.872 0 0 0 .878-.867V14.71l8.608 12.478c.23.334.613.535 1.022.535h3.46a.872.872 0 0 0 .877-.867V8.178a.87.87 0 0 0-.876-.867zm40.71 10.3c0 3.323-2.712 6.016-6.056 6.016-3.345 0-6.056-2.693-6.056-6.015v-.22c0-3.322 2.71-6.015 6.056-6.015 3.344 0 6.055 2.693 6.055 6.015v.22zm-6.056-10.44c-5.694 0-10.31 4.576-10.31 10.22v.22c0 5.646 4.616 10.22 10.31 10.22 5.693 0 10.308-4.574 10.308-10.22v-.22c0-5.644-4.615-10.22-10.308-10.22z" fill="#FFF"></path></g></symbol><symbol id="wds-icons-dropdown-tiny" viewbox="0 0 12 12"><use fill-rule="evenodd" xlink:href="#dropdown-tiny-a"></use></symbol><symbol id="wds-icons-magnifying-glass-small" viewbox="0 0 18 18"><path d="M11.563 11.504l-.03.029-.03.031A4.984 4.984 0 0 1 8 13c-2.757 0-5-2.243-5-5s2.243-5 5-5c2.756 0 5 2.243 5 5a4.983 4.983 0 0 1-1.437 3.504m5.144 3.789l-3.103-3.103A6.963 6.963 0 0 0 15 8c0-3.859-3.141-7-7-7-3.86 0-7 3.141-7 7s3.14 7 7 7a6.956 6.956 0 0 0 4.189-1.396l3.103 3.103a1.001 1.001 0 0 0 1.415-1.414" fill-rule="evenodd"></path></symbol><symbol id="wds-icons-magnifying-glass" viewbox="0 0 24 24"><path d="M10.5 18C6.364 18 3 14.636 3 10.5S6.364 3 10.5 3 18 6.364 18 10.5 14.636 18 10.5 18m12.207 3.293l-4.823-4.822A9.455 9.455 0 0 0 20 10.5C20 5.262 15.738 1 10.5 1S1 5.262 1 10.5 5.262 20 10.5 20c2.26 0 4.338-.793 5.97-2.115l4.823 4.822a.997.997 0 0 0 1.414 0 .999.999 0 0 0 0-1.414"></path></symbol><symbol id="wds-icons-arrow-small" viewbox="0 0 18 18"><use xlink:href="#arrow-small"></use></symbol><symbol id="wds-icons-avatar" viewbox="0 0 24 24"><use fill-rule="evenodd" xlink:href="#user-avatar-a"></use></symbol><symbol id="wds-icons-page-small" viewbox="0 0 18 18"><path d="M10 12v2.586L12.586 12H10zm-6 4h4v-5a1 1 0 0 1 1-1h5V2H4v14zm5 2H3a1 1 0 0 1-1-1V1a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v9.992c0 .043-.002.086-.007.128l-.001.003v.006a1.19 1.19 0 0 1-.023.119l-.001.002-.001.006-.001.002v.001a1 1 0 0 1-.254.444s-.002 0-.002.002h-.001l-.002.002-6 6-.003.004-.003.002-.001.001a1.003 1.003 0 0 1-.435.251h-.004a.885.885 0 0 1-.136.027h-.004c-.001.001.005.004-.004.001l-.003.001A1.088 1.088 0 0 1 9 18z"></path></symbol><symbol id="wds-icons-menu-control-tiny" viewbox="0 0 12 12"><path d="M11.707 3.293a.999.999 0 0 0-1.414 0L6 7.586 1.707 3.293A.999.999 0 1 0 .293 4.707l5 5a.997.997 0 0 0 1.414 0l5-5a.999.999 0 0 0 0-1.414" fill-rule="evenodd"></path></symbol><symbol id="wds-icons-book-tiny" viewbox="0 0 12 12"><use fill-rule="evenodd" xlink:href="#book-tiny"></use></symbol><symbol id="wds-icons-share-small" viewbox="0 0 18 18"><use fill-rule="evenodd" xlink:href="#share-small"></use></symbol><symbol id="wds-icons-pencil-small" viewbox="0 0 18 18"><use fill-rule="evenodd" xlink:href="#pencil-small"></use></symbol><symbol id="wds-icons-youtube" viewbox="0 0 24 24"><path d="M23.8 7.6s-.2-1.7-1-2.4c-.9-1-1.9-1-2.4-1C17 4 12 4 12 4s-5 0-8.4.2c-.5.1-1.5.1-2.4 1-.7.7-1 2.4-1 2.4S0 9.5 0 11.5v1.8c0 1.9.2 3.9.2 3.9s.2 1.7 1 2.4c.9 1 2.1.9 2.6 1 1.9.2 8.2.2 8.2.2s5 0 8.4-.3c.5-.1 1.5-.1 2.4-1 .7-.7 1-2.4 1-2.4s.2-1.9.2-3.9v-1.8c0-1.9-.2-3.8-.2-3.8zM9.5 15.5V8.8l6.5 3.4-6.5 3.3z"></path></symbol><symbol id="wds-icons-instagram" viewbox="0 0 24 24"><g fill-rule="evenodd"><path d="M12 2.162c3.204 0 3.584.012 4.849.07 1.366.062 2.633.336 3.608 1.311.975.975 1.249 2.242 1.311 3.608.058 1.265.07 1.645.07 4.849s-.012 3.584-.07 4.849c-.062 1.366-.336 2.633-1.311 3.608-.975.975-2.242 1.249-3.608 1.311-1.265.058-1.645.07-4.849.07s-3.584-.012-4.849-.07c-1.366-.062-2.633-.336-3.608-1.311-.975-.975-1.249-2.242-1.311-3.608-.058-1.265-.07-1.645-.07-4.849s.012-3.584.07-4.849c.062-1.366.336-2.633 1.311-3.608.975-.975 2.242-1.249 3.608-1.311 1.265-.058 1.645-.07 4.849-.07zM12 0C8.741 0 8.332.014 7.052.072c-1.95.089-3.663.567-5.038 1.942C.639 3.389.161 5.102.072 7.052.014 8.332 0 8.741 0 12c0 3.259.014 3.668.072 4.948.089 1.95.567 3.663 1.942 5.038 1.375 1.375 3.088 1.853 5.038 1.942C8.332 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 1.95-.089 3.663-.567 5.038-1.942 1.375-1.375 1.853-3.088 1.942-5.038.058-1.28.072-1.689.072-4.948 0-3.259-.014-3.668-.072-4.948-.089-1.95-.567-3.663-1.942-5.038C20.611.639 18.898.161 16.948.072 15.668.014 15.259 0 12 0z"></path><path d="M12 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8z"></path><circle cx="18.406" cy="5.594" r="1.44"></circle></g></symbol><symbol id="wds-icons-linkedin" viewbox="0 0 24 24"><path d="M.351 24h4.982V7.93H.351zM18.035 7.509c-2.386 0-4.07 1.333-4.702 2.596h-.07V7.93H8.491V24h4.983v-7.93c0-2.105.421-4.14 3.017-4.14 2.597 0 2.597 2.386 2.597 4.28V24H24v-8.842c0-4.351-.912-7.65-5.965-7.65M2.877 0A2.845 2.845 0 0 0 0 2.877a2.845 2.845 0 0 0 2.877 2.877c1.614 0 2.877-1.333 2.877-2.877A2.845 2.845 0 0 0 2.877 0"></path></symbol><symbol id="wds-company-store-logo-fandom" viewbox="0 0 78 78"><g transform="translate(-.667)" fill="none" fill-rule="evenodd"><mask id="mask-2" fill="#fff"><use xlink:href="#path-1"></use></mask><use fill-opacity=".405" fill="#FFE2E2" xlink:href="#path-1"></use><image mask="url(#mask-2)" x="-2" y="-1" width="83.333" height="83.889" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAIAAAB7GkOtAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAd1JJREFUeNrsvQmYZVV5Lrzr1Kl5nrurq7uhLzagEVs7MYgTBkQj0ER+0aC201VirhOG5BowiSROv4lGjFEU7k1QfyGAv/4ImmjEsZGOPxgBFWwM0gPd9Eh1zcOpqvvtWqd27drD2muv9e199j7nfamnnqaqzjrrfHut913Dt95VZ+15xJLikk0jljHu2HfAAnKCE70F80Le3D6cnWbD8ol6TyxW01Nm6df/PHEQgc3mo7nnyNFjM7ORf1ZAuAEAAGoTEAAAAAAIAAAAAAABAAAAACAAAAAAAAQAAAAAgAAAAAAAEAAAAAAAAgAAAABAAAAAAAAIAAAAAJBFFBECwAMWb5ZL2qvtE2XHUIilJhZsfADMAAAAACAAAAAAAAQAAAAAgAAAAAAAEAAAAAAAAgAAAABAAAAAAICcAucA2MCSnb1jfGnX/BKCCQAABAAAACANpHkVuxz/zHJGb0bpjB6WgAAAADADCMEd+w5kRF1ZagIAAABgBgAAAAABAAAAACAAAAAAAAQAAAAAgAAAAAAAEAAAAAAAAgAAAABAAAAAAAAIAAAAAAABAAAAACAAAAAAQMYAN1DACxZf696qM27qPbGImgCYAQAAAAAQAAAAAAACAAAAAEAAAAAAAAgAAAAAAAEAAAAAIAAAAABA5YFzAGxAdjYAABAAAACAnOGOzBxdTHMoiSUgAAAAzABqQ10BAAAAzAAAAAAgAAAAAAAEAAAAAIAAAAAAANWMmJvAc3PW4nKKUnMzYgcAAFAbAjA2Zo2eLLO/QHu71dtjFYznEDMz1ti4NTVV/t/WVquzg0dgSiW7ZBKtcsktduFFjsQnigNVeGbWfovGRqu5yS6ZC1Thqenl6VkdW4WdgNCXXXLBrjYAALWNOmvPI9F/dey4NTERJB9Fa92QEUOdeMqWFj9IXfr7jD4ZVZgKX1x7pIKIj0SLCjck6CNHy0zqgPiUKmzIqlRbKpkU0Y3OTrvO5opF+u0ONT01qnCQ0PLcCMZymIVCLSSc6k+x5RoZOC2ktLAcinrTJhE2UaYgF7kzral5QL+B9AQgjKMd4hter/nmVCwVHgYT4qPhOTFpGAYH9Afs1LefPOzVFYdSKRTaUyIq8+Ahr65waQCV7MyEokLBIwDHSqazQyJoGnl4QKJlTtZ+CadnR6EwZ1W/hLPot4CQcEdaQvRbMyBUOPUaemRUYRLaAtPuINWWnuPi0vKoro1ZDqlwqnkSKlsziHrM9irKWETTCZwcKI5J5fIQyFkq8BOHR9K0Qd17cTE8VuNGk6FA9jcMhWDSsJfLA2UCkyCLdhVYN/qhs1qozRok4Z5Q0/9Knmys5uGZwMlHObHYf3R0tYZUYfoUJq3CM6YRUbV75ahs8KQRavr4VCZ90ShEjyvCGti+/Xb5B57gibBnfECF03eWCHsmcPQoPY0kuwKg0tkmJjUH6ZH9LaGSqfPoPQBqDWEc7fR2bchDrReKcq3GZV3UkE8lqmPCp5I6y8cN2hWjJ2tIT/a20ExwqzCUFsHL7KFwNNVTPfoULExNvOwmUHoX/6qs9kN09zWxQ8kF4n3BIfQ9bLqvHRAqkB4lfWfUQqfw+IoVOQNYUNI0DaiUrCe/c/OJlTwX3VFNOjl7hVVeqxKuJN43cuqZRLE2TU/r/Mqw4RnWOezlLAPJwMJnZnloOnDRhqHkyURCIcpxtz2uCvsHiIyKJUqmL1IsmmbFKTlq7WwRFsepIEtxjrF/S9Pkmmkh0Vsj9lp/D1tsAdnAFQeYPASy5ApOHd8MQGV3RW/rTKWWeiU3NiRWcmNS7ZJeKH+tyf6k/CEW6/VLltfKZGtO8lrDrdrWFp1fVRZhH5llEzgw1M1NDCX7Uy248pf8T4prP5yq5w4Ib8JVZ+fqv7u7OFsIBURshg8OrHkXUwFob4suQ+VvAl7VnlTJ1OzkZEph0msu1BTkrcHkNID8tSbcJAk1BcqkzpIHZHiCQVKyYc+haAQ2D/ohbzIo74C3u5s/FKsTF187ZwkFlexpAywnh8RDdNMcNTYuPqXqEYcKfqDv64Y4Zxv08alAepTD65kbGz2ykQ32V8zubJwGapL7KBIbJM9Y+yiAPA2UnoH2eGFuzl5lC2s69ACSSAM1PBUhkjGU00DjIfCMCDVH854TmAbKklXpz+WlqlKFpepe+eMR7p5I/Y7iwHX8UBzGdA75Mw5OxVaq2PBjTwMVBxtxKsIACgIQeDrJaYWG2dNhR8xYDoL56YPlIBiFwp8yyJJILnIfPUzNdRCM6MMdakYGsVMyVk5cU7H26IwpkVwcBHNOLzMeBBP56WKrs7kpdFqQKQGwXHuS8GIBUhIAp5PTgN0ZnzIeGPFYQVDLpmJZiEkk5lP51Gdsw4blkrmsICggZcOGQtlkgmuqSKFw8kl4B02OFQQYRGP8nZ0D0gCQtgC4ByCYcwEQAAgAkH/EHF0S9WPkCAAAUCUCIBYcivXRKS5xISyxMF0AAACoBC7ZNBIlAO5sGRrd9/Yw8HVyGwZiV1Cc1hPZnO1tPJMSz7K+2sZgjIA4J5+pZMZZlOMdTRLOuA9hufYbIeEAULUzADeIWJ88HJkPFwF/Yo9wMqGphmFqoCdtVJi30Jd5nozfO5pqS29nGAorxDuaBGBwwJSs/dlZhafsUJjn8Pm9o7lGBk5g3SlDXEmHdnuYLAdEjAwY98+p2r3JnBJwduYpvDjgClRSAKyVnPG1+ezxtr96ByxrIODHP/2NTVhEqfqzipBDA0RV9kkZXR4hygg0nhShMNGAMO9oIbTaNtpWSGq/YxlmSKn+rF+WkYHlO1NCxEcVpu+GKb9+CbdTy8YYUn4tV27uCLcAUG095qbd3Wxy6PaOJjmkCHPJof3UVub3XAl7nhltYwNzsYCqADgDQC4Tcw+PUEfV6JMijV3W3Ef1l5gklsjifbVFS+J9KGy0tenJfdOZPxQmg187O34mlK1MREuQcuA7Um1NiI/IyB9qUWHDnS0xzZJbwDIKLT27Ql2so/xKc2V6l4OHjE4pho1pqGSuCw88M1qWs4T+8QHLSSA/RYgVaa5zzhUWgPKEtyeRNyR514i+knf0hE7P8Zj/Bf6BaDcarCR3KJyY1G+Ici9ZCpc2iUh8p6nzixMV2qIV+qsxIwFwTrEGUuHggBFxJMT+FMlg7+hxBgHwCy3XqM4vtPReNOAwXx4Ue3vu+MRcMJAtVPR2WpuUorpjfGnX/JKmilNT0R4sBrY9GsGwX9GzFoVQ8koIeiWreEcvLmn2Q5a/0fikCbklK4ZLIngJ1VlSsqHpruS1hi7BLK7IsSpm3vWcCykZn5282oY22mFjmsjBWcXhGeTxVlgMxcS6Lk3gkrlDBptOAAAAXISaDKM2NyeUiRdS3eTu2NQrWcWyWM/WWCUjMyHvaJNk0OQcnuW1MmmFkpINM00lrzXcS2RxRY5VMfOuF5ZNxJJ8HFgIi422fzmU3ivjl/16fIV587A7O8pdo7fH3sNPdQkouS14vbYSGVltW2OP/Xdgu9QLfWSVEnJ4Nnx8Eh9mw2GIaNDBv+o07Sphz0jypopxToiDRAqsHyx7b/5C6O0MQ+GU7Ak1PTuWwWl315qAUJnmuWEpYHDAzt0SedImu02BvfiUzdamjQx7QpJmGMxcvJcVuBlEb9tTyKAkXcdk/50em8Th2SQUVCuxh8wYCofX7CPcc8FvamTE324vfPsXZMUjMHz61KX9D9H8KAB93nVDAQ7P5mcXhDu836KVBSKe7lBTfFjGXmLUIrJTxP9yJagI33lhpEphp0EM46lG+vh2w85VGmiZIrqsfKIY8Hl470BwNx0ThRR0GagBpMAmZCoq5r8aWzg8G15rRcH00wc1bsPRjXhM3oNgTCluImfcfZU5VdhQV9wDapHDSoXbF4+08eTkOcQkNiSFPyvL4J1KHl7Pf4W3eF4UaqKPJA6C0cdPiEPLeSnJEBK7IQ0QQwDEWCyhOa9JCrlTPRpujJ5cYwVBQwbzFkNdZaR5lT4Eg7BYQTj0QSMmqjP9L9egSWiAyCZcXLIHTVQsF4NQMxDERF+89n9UWkJ+gmViSoaZkrssTNzkBwCVEQAaN4kBSC5sPqmrJLQymDR9JMQgiY6YwE0AUOUCgE4OAABQowIAANWOSFNcFfTuO4BIAhAAbkxNrTkF3thoL+uzLJiIKyHd1xLk7kpIKplxhSehDQMB8QRhaQkAVSUAdipIYl3a7x0tzBeJWw3PPvgvhRdmZFSsoboQQXtShugnxZOJXApvm9wxXQrvTxniSjp0G09arEmH7vuiGS+LThrOJQ28+m3hUnggfQGg7p3QviuVHJZdR33+REH/ff3s75Yc7VNjgpLcV+i4Zxs+G+3YfTvQO1pwq8kjCPOOpg9ComVIqX4Jp/+l9zJPJvY8RIo8fZG6ZPl8kEdoSb9Fyi+LHLrNtBn1u9zdlg8NULEiFZBrGufMlUXKL68ciiw1XFhkgEJ0iAMtfFkeXpi/v9P/9fyPIr2j5b+N5Dvt943s3mGWltqhKEtIuHe0//RDXI4OlHB6O5NQWOGXNNhsMpXd/kRC63lS4gIcXvYPnNKZsL9jeU3F0rvQp+Dq4weesGsuJt8HD3Eep6BiqXCqKhUbOHIymcBRmY/vtb+zHwAUtyVmpg1HCYDEHNi82UX/zbQmd8hbQ6RRs6RlyN3+TJ6r/LUmD0JSMgXKpM6SWhkaKUu8ow2lJTmEnc12r49pj6MDx2GSKMViUn87Z2Fq/5hGMsqJS6PugIilQq4pizNdDrvQySQgNKyhgS8pLu/AmqpKcrhvf9wHV4wOR1KT5SWlT6UTi3mlkl2rqMpXnjVb604N+92ORw/tGp/Rb3aRomXSOGQlLyRWckl/y10SjcxaBEsa3tr2xhZnlhlAYDxnZhkSMfxjC7GHYb6B4R95cLkle8y0uSrsDAUc0DyA8dQRjZXFcySBiWOih4QNAAD8xFBA9fL0ERwDYCo2zqirqFouO1RK1vRhblAYyjdn66HSC+lLMuw1dEuWDNVVwiUJo2QFyaTOkkac2R2/MO9o811KkVzrbx4sm8CBzcOkVTigOYRnRYJrw7a9zdvwWCyprRXLWycgHsNnQ3R3r2588hpuOh6Oa1Mk7og6vBJFWAn6QiskzusZ2Ea6gNFvEyIRkzmd/LUSl2aV3iIJRULe0YZOSpLu0Z1V58UwmyN6sobDvUBXWtu8hMPh2Z+kxOVc4nFjFWaFLCNfarREpu4IMy6nrBuyy6dHSd8Zr3gUTXd4vV3myAZ+bxiKLX3F7M6RM4BiUvY4kQ7P9L7aK8jUpiWZDLy23e6RVJtBh5Q4PBtartPLJyaDSzZMqaTW5h/liVAYnl0Qpk/+PUPG3MckIGxl3YNTCj6LYoluOHqyHBBhVcsyjhF+hSJVTJxq5OImKo1KFgcbC3Vs/qwOmVKXoTqzm9kID/CEkNz8VbiZxe1nKsLSu+do8OYyfRiTdG9qZ6WF4GRQcZjIZCwWSB8iezqhZ9Dba80vGT0/v8OzmDaaMwiVLI5ruZ8dSyhsRm6xBUawnkj3Zhk0CPNXJ4eV8SB3chDc4Vz4zkt5YpwraJo3DlQay0U0YaOE1sSijQNxhk9etZM3N61JJxf3GZnfVU/URvQhrCDEmQ5x4NP8uVL1qOUl4fCcKH0Ih+eyyQTfoEnMtyja4gnyDpqSs55PlJiSQ6IWrTj0BKQtAFbChsZ5dHjOI31gxFTjoIEF12Zp9vDm9mHzQh6ZOmrNz5qUoJxTLsOO8aVdJssJ/AIA1Aj2HVhdwiZhzsW9rICM0vZYP7rXuv+BNY/1zK3WKy/CwwXEzX/LUsNuXOU2+IRDZPbHht+62/rWd73ZdZs2Wi/7PeuFz0OEcvlMv3aX/Vg9OHbclgT6etl51usuQ5xqWwCcg+Cjo2ypBR57SGslF8JcBtz2kNby6jPLhkGiEH5YM7P2P+y04ibOxTTHO9pkw4BG/dddH5yRtW+/deMXrF33Wu/5Y87Vg1KpfCcwkBz7f+Tv7ccnAWkDtZ+3vRHRqmEB8HTLg4eMHCLDPKpID+iHhg6RHj8sQX/0lWWHSOEe6tZC28ZknMEs0+8dTfHR8I4m9iemkDsCPbzH/ptr/oRBA+gJ0scXx9bLmzQdPBNE217wZLlkEkL2262Fp1uxnvPuB2vlkgaxPcNVYRX2F6B5AAEaUKsIasdEK9p2K+LG9rCGbuIy6MlidEMY7JkMohNCmJmUYSisEIdnQa+xvNJU2N+ZCth/OW1UbWpawnbY+RQ072Tx26I2cOCJsm0qfTn/yykAo/YXfQQuk0jxEKk04REmjDPTZH9HA2iSF6tV05iGyud193Q6o3CJT86FDIgQALtbavFppHe0tstgmBuiu3Nqi1Zy7pKSkikUJnaAEldFKlYxFOrsz6IB9EZh3tGGVo70eQPXr+iHXB5hKm8XF/65Mj07Q+/ouOwfVwPE2IUepXBJoziwhEL0cVIUiolQWZJDdivmJCDWPCgmhs7qYS0t0tuYXwC0B8XJOTyLBpfEQF6cP0gCkabTJqNpc+/ouOxvrgGSWhla40pIk8sl2M+DhhNH57AYYyj02D+WBvhpTtz/wzJacpcjiDX7EHIoJp28FaYyxVUHSWghdRmq7dxcIVTWdMRQIXFVr2QVy+JFrbTZmdmkWkakrpg8VEPvaD32N9QAiRzSxzEZqks+b3KjSBXXcQ351x7umbC/ugYExtNwYTCseYgLv7IMioY7ILyjSWeWb69/cI9jaJq1vNpW89mZhbrKvXWhMiWbsL+JBshrVWuJwrwNz5z9Y80DUmu02Xf+SK4Zuz87exxEgY2Nxej35m3TegFSMafVc65OLoU0MsfR0C1ZMtaQhMKc/d0aECsviD5vWJ0NXYLptWETiOXnG2mKGwrJ5dKGCVGtrcFbRHpdj1jbnP0dDbDC84Ionv5Qm1jVugPimV5k/9S6MNN1ehOv04ztaFmyYyJcsHjR3WXPKrq7Qqqrl6iukjyq90moKUSOH/VSVym4yd0NIA+jkcNzu877Ut9mYX+9eYDk0Ru63YUdMQl0UY4b50BlEq7xhtwRaFKi4X1E7H//zzibrmQeQKzkkSj/T7QforvdUoSTs+RkBFWSItDdzX9sXnipnrLZ/s4+P15xug7pNno0bSdfd0e8qx7bChdPCUx8xpOzG6OSw/qG8Koz6S1hBBQWCtGreXNeY2mAsGgNDIWhX5Mw0fOEOvCHGqBCPI2Wi5voSbk/uGjkcVsFPVMxZudFmAZQPImPBOXRF6+vPRVLBVLAhWl+XlYFKQIe9co+xA1UAV5Aottoh54CEZaySS3bRCHFywMdnqkjmUQ/UYduCqY/GVHjuFYgMVE03ImVEgZJbm031lqQcHh2H9eiaRDLDEyY2otz0fYZ4wa2+bjHopXXMcVt0aoRh4TYX74WFDm1NZwYFWFQlh6Kawf+HMcy7VtpVhyeBVnbdsEct0x4DOKtPHjEU92IPuzTSSvpRlwMIuie6EMkS0jurkt6Zy+WBoibXhKS2+SIKYMWrYmyv1wDgOoRgFM2l2/VYZxwhd2Nx8KneTSITzQgcv1LJ69DY08YMEEK7O+0HxLsV16EkFfvDKDmPbl6T1TpufM0s/qgAdXH/gJfu8vWADjCViPijPpLpbLrztgY//kacW424+c+wP4qGsByLAjICPtX8E2BlGYAkRDuQJ6t3eZmezXGfPYgRMWhfnHZJMs92vb57MmyjYRYIufacrRdj1xbEYyXTVJV7ZPls/ZbUGypZL0KV+pED+YB1UrEojlhHlBzAhBmPEn0Sj9fN2SkAceOew3CbFPf5WPKvN7RYvpCX+Z3rPsPB1EoSMMMQ2Gt+Cw6WmhffjBWTn+KFYoKnufk1QDhDencY8yYbGe3h8mVq9u5L4t2LmlobOC8Lbniw3BoQNVBodF7TOf92qDtXuLJYvRQoYnLoG06H2KqRepi4mFLfTuwYiIUJktY9NrAEsLeMZvs79YAw7Ugah7LflWr8eHynhQ2W9QShHc0vRGX3xYV4lha0pfwiWRxc8zIIkzcaoinRkEIvCbEPNriCQJJzQCWXQ9PPOfURN68t8+y4mUEKt2VHGlnTR1eeyApcXgW76ud40ivDWMKYTeoshaUBfZnmQeI2U/g9MvwSjWiJM8VPY5+D683TSn2j5aEwBhmvmZqCV59HuC5D4OaMcWBaw7nXjygmffyuVYe0CMTd6KInEPGOVz+ZgB53NCL9I7W9p6kBi0f45ucs5XPS1QcnrPD/ubzAIn9oaFjPpUc2DzsmzsnjUoOM0amn5tMDTO4AatYJf+xTZPLpjxtwN1fKOxct3oIG2pRSTF9ycXVNBQBmsVSj4u5vFGMDkfuoOIdPTOrs7kaGQ3tcEX2isg/yBr7G84DJJE0ZBDJUo89LOhKpOGJ4WR1sL/6PCBwmKUdCnnJU1P6ln+ekt1tT9x7E4crZDnlj+91jb0L1qaNfKPe6XK/IMWKM8eqVTvoCrpAB9fH7EFkk/3N5wH5egqVGmjXYPX8TyoXh5nc1eZtbI5fckxxjaqEnsdyZdHcpPA3WrmVkcHVHtqseDOFP+DGXLK/tgZIImmYyCuZiximLYU1PD2zh1yk3ssr6R+KGvp+O/C7VXKlHXt8Xnndgh0XA+FgxojW1nK0Y+42FaLLzZ8ANEcQsbaXr8RvJ6zFx2jTnfFafF7YX08DwhyeLSsph2f6oeH+JLWNwP6iUeEcHbySVJU4zt1fDI0mPaF250bbJmadbJ+IKilsx+g7496yaHvC7pS+s1Or8KOOKVd11p5HIv5k9OSJLVmx31HKArJWsvHChmMmCfulkl1y4Aq1MKTURth5C5tBQs4u5IX9HWzaGGM/wJND4rRy8zQSf6hFGok5N/mPTGqcO8njsdu3vTF0P0AYqTY2RN/qoYGZGfvZFWr+ZkNdKAiAZZ3ozUp8VQVAtAx/th8N4QcHGI5r+bP9hEe8YUOk2lLJ7lQicaVJ4Ogmp6fzY2mAnZkzYe/Y0z/EQW5G59eEjmtZrstsNbgpv6YLEg0AIABpC4CHPuwrw1rsfs41WBCGDSJDoLmJc6GwbIu0IBs05dqbJZYG1BTybrkDDYAAZEgAQBPQADzWlPGhv7A2jeBh5gVYOwNNVALwDa3Kx0qgx8qSjw+kJACjJ8tfvLfFAqAJaEANPlaiEWhAflBnfftbq/8X4n2RoSWgw5O7jo56r4RkcRehMsU1lsKHmb66u3i2HKlA6hWC6cRWhF6Fq9KTHWtBVflYiUPosWItKGcCIODLtMuQADx6aNe47xQ41dbQbMvv8BwSCp2S/Y4oGslIVXwjB5cG2P5xK5c0iJEB1868k01gWWUrOq5Ugip+rNCAPCCoHXMZNqUGQbLs7C9CYWI2K2wF/YcGAg0pa5MmLKa1IHqITx62Z1oiBZP+Qf9r4vvtnhoeeMJuYPY0borTO7q6H6vGWhD1iLGx8oo0OwXhzkFVAbCMDRfTB7Ub7UcrFw8TaZG8VlxQk1WaaG9p2rZlw7qezpTez1ADhNCy67cVcuOFMIw09En81ner/5LFWBogQk1dRlylcPAQ572zQrapfKHljBDHFR/fu+builyI1jL/FEKfXO6g5+XrMf8LfMB6D4BeJW8QKnxXCfZ/8/m/+40PXPGpKy699X1vpO8kBlnXAMmjl9hKK3aSwOYhJhnaoGf65dtqYoSprgHEy+7+IlSWBZ67JejfjHfIOBfd0CflqrDDPKSCpC70nf3SGwrC8kpPIVSNawRiYTeSyvUEILJdZo/9r77s/Ded/1znf2kekAMNkITacFAmqYyK63gY++fLwCMdDfB3h8ghlHYfV+n1ihztbnvOCXAWOFNP85sq/PQupkGjJ2v+HEAFfaHlKUaVYP+/ev1Fv//bT/f88LT1/fmYBwQ/30KCzwjsz6gBgU+KPf68vd5TPfpfxgq7Uxja21g//or3cHNTIaV2nwaf1ptG2eRv/IhM8pH8QSXY/9qdO3Y8b1tza1tdXV3ONEDygAx9nyTW4s3xo1Gb7K+oAX47Jq5sK2JPjxE/l/UTFeVkCdK/Bwc4I9bbU2698T0+oyEcSdvbQ+LLdW9negN53Yca6fetHQp34whEmMNzhdj/orPPWq51ff40gCIZyBTCSs+IO0K8o6mxxe2Ttcz+KhrgMT2k8HI55tNwlvhOPC9h+8o4wCV2Hl5ve76aeAyHVZtKPmVzImxMVV0OQr21c2fAG9OnclHA+1qycn/WLScm9s0FrbIN9OtHn144OWUtLQX/ikqu0/341OamZ6yFhWBmyYzHp8P+AnV1hfpicaE07x2RdLT+7umbv/vgo3Pay9/qODlmPfhL6+zfsRoaov+YHlBLizU7tybU1IyHBpVeLkdbmzVfsuZd0aAHR9wUq1WA/QUojLvvs856htUV1PjpIVJs6TvxKf2jjo926uvtHkfFdnTY/+YFFUg9vb4+jw/EJwCC8tYqZKYFgEZ5VGGTOR09OT99CPomBjGZhFILJvqY9eURUePu680m++dVA+ghUt+m1tvQWDaO7u/n6ZPiIVIDa2qyv/f22v8L9k9IAyiwRD7w908LdSeO7Yn8o9genMR3oyftLXL6ErdotbedGGZYd9txcmHXU+OriwPCVoHR4Xlu3s5GYHd4FndiWMu7T0Qi/hko/fbLt2WE/R0sLi7MTE0u+eZGvz507D03fHViejaNKubdKwLsHwicE65mAQgCi59EddpBE/vba6P7M8X+0ACwPx5r1QNTLbC/tH0E7QkXCoXfOmXDZ/74srzmhoL9swDYweZsBiBOPy4uDwbjr5BgBpA79g+cB3R3dnavbF///PEnLv/IjWPp9OF8DRgzwP5bNwyederw09b3r+vpPG24v30lb5XknESdpH18embPgcOHjp/81YEn7390L/0b8wAIQBDtnlzYdeiY9+x7TEvLCggAVXhicrXara1sDpEe72gqk0qOm1uWE/Z3a0BfT0/72v32X+49+JoP3wANyA77n/us08896/QXP2trR0vz7Mx0aT7gMK2jAe4fkh784IE9d+5+gMQAGgABcNHufx3edTLE+cRJsM2aABw7Huy2lpB3dKFgpwaqZ+xWiP3/8rWvuOT5z9F7bV9Pd/3Son8/IJcaIPIURHYWKTfX3Q+VY3+i+8t/77mXv+S59A/3z2NpgADNCW7+3n/ctftBkgRoAAQgxIXfIb6RDSp5OKkKgO0oOxr6W2LqTl2fS4nlEwVheL0Sj1SI/a++7PyXbz+zqbml2BD7zMRAX19He9viwsLUxHjuNcAv4XH1O0vsT4x/xYUvIuoP+wMNDRATglu+95MbvvHD7GqASNtrbGA72euGyAaEAEQIAKG7W+W8ZXoCsLhom75K/OyURSsAxNqSklWmFxVlf/HvuBog2L8c3bxrAI36qXmY6HeW2J94n9jfM+rn0gAxG7j2S19PaVFI/bEKr1DHP06c7+VKB3cuceIaFrirLZaOSVoMz6gHFi5WpOOAI2RZ846OdHim3+rZq0aWHGnxnwH2l9BBJPvbLaa+vrW9w+8V8fTNw7e+/4rOdGbxJgkkYQbRonPmh/2H+7o/f+XOq151QST7SySfhHxmanJxMfRY3/q+LnqXa3fuUHmX9B6roFEHc3NsLv/CKdOx4eS9HYtKGx21a07f2a8loGHNwUNxiy3wvHemMDfP8zeBg0cjpawQ+7/6pW72j6UBHvavBg2QNFftlpw6+5/7rNO/fPVbtz9ts/pLtDWAcNHZZ9189du2jgxl5bH6B3Bcw1BqA55BHqMAuCvJcl2dm1tEtcfGYjXjWj0HoOcHa7I+ULmcn1e+8LfrgqwLIjUgkP2rZB4Q/Km0ukPq7P+2V7zw41dcpjEkN9EAmgqQBlx89rMy8Vj9T4rLiC1RFwp34byOy443bUxLao5Pm8QOjFF9FNhHb3snMrJhf1DRjM8wg0+5BkjYP98aIPlQGnVOnf2vvuz8N5y7fWlJ8zSMiQYQPrDz4isufFHlH6vfSTfMWzcuPPbAkW7BseD4m5ISGOYi+glNmOIMDsTSMBYByFjyFj0z+XCAgqU3XiB+l6td4H5RBvL942pAJPvnWAPCHJ7ph3G3+yrB/i/ffmaYP0c6GnDFK15ETavCj5W6MDGdGG+JrVrGYSiV3N29vE+7bPLMCGpgp2y2y9y0kdk72lr2045vSW2cBURhUotRqmmg4qbmwA1bai4mzt2SFCMqc3h9BtnfVfdQ4nCTgiL7rxabu7wgTw6JQyixpv8VYn9XQw4VdRUsLZaKdXWNjY3F+vrGhobCymenAknUSdoXFxfn5ubnS6W5+bnpmdm5tSvLd+1+8NovfT1bjxWIDzUBeOLkrsMnghd/aCKj1m3SPghG7ZU6uWcDhziaKmyovX76CAtF9s76RmpAXPbPqwaIFiIeosaMsNLsr60Bba0t9B99J8anljA/F5wbKjRgbctZnJyanpicnF5p+dCAmhEAot3peft0lTA/IJoTlutxpl2V8QKamLATfqiV22t5TZzzRMfh2VpeVg50eM6k04NEA0Y2jPT0aF7DVCVnxDLJ/vRMX7rtaYG7NYoaQHTf1dnR0dZWXNtQY2mAQKlUOjk+Pj4xSZKQngZ86P0g64oKAOygYyHbPj+BGtDf29ve2kps0qA7Q6oJDagE+4tnGrZjL9cAQf1dHR2FkJm6hgaICQHJwFOjJ1PSgBc+z3rbG8HX7IAddALYdyDjLm9+yhDsL6EDpWKrMjc0G+xvhW/eSqZ0RP2bNgz3dHUVwtdpwySfCiQ5X1xYCNMVKpYKv+zc56axJwxv7ZwJQKlkL7+Mnox7MEG1cLEYBfaPz/5+DXDYXz4krHUNeGRPBdk/rgYUi8XhoaG+np6CwhadngaId1k/NPjmC1/yN2+8BBqQR9S/73++K/KPbpmz9i2qLwQsWsdP2IeeqQcSTU/PWOMT1szs+wYYEnXtO4GfPGrrysSkfRycvi8u8STqUlVPPGUdPbYsWuP2PeDUc+Ie1hDsn7o3hp7Ds7j4t6ezo923NVKanyeFqNe6U7euUCg2NASklnZ3nHvW1jt3Pzg7n7xyx7pPWPHJ/t2n11wNX6FnWiw2EC/7kzXphwulEkWe1LettWX94GBDnM9OukKFBnI9PUq72HAhaWpsfM7pW3ramu/+z4cTH10RsWzfBuLO6gyA2P/JwwGnnGeYfGWpZPfA3zb1HbUdMBYXjYol6qdqO8RNpdEbBX6Q7LH/cn7IGXqvHRoYHBwcClw+xjyggk9WrujyeQAJ+tDAQCH+iVbteYCYClxxyUs//seXYx5Q2wJw5GgFrIHoHf0G/eoYG7O/AmHPY6ayyREu9j8zlrnb6pB8OeMzjKyhAWX8+rFMsb9cA3q7u1oaitpnxEw0gCTnLRe+5FPv2plRDRBZv1kzLqsqAXASq9OH7Qyu9WhpsD96MmJykG32F/+OqwHufH9ogOzJfvwfs8b+YRog9nLCcrFS0ADCzpe98DPvfVPmNIBGcgcP2XN6+m4yWAwkvQNPWI/vtUtmVxdt32Jl1Fnf/lagmtvpdHEhv4al3L6adU5X0wg9kojVriUIUI6wC14cjGyQbQZkgP0jB4YS9l9tbOHEUaO5oRlb+QmEI/yenXyJqKtALzfUwS13//gdn7wp8Xgp5ob6+3h/H5vLP7G/syhNLEFcwSgtws6A97YDh6st20CpGKo8mcJiYrn/Kr7Q9IDDBKBC7P+Xr33F+Wf9t0A6sJY39OKyv0MZgWRNdEDf9TQgrFgxD0hJA2ge8Bcfsq78Y2vTSIwx5pdvzzj7C8m3Bz8d7Z6dfKG72hpAkk/f/Rog5gGRGnD5eefQ98Q1gJ4RIVID/H28tMDG0Z4tyVLpki2nmBd8z5GjxxzLGXoX4uveHra4ia3T5ZLrrZ07QwfUsYcNs9ETFmJSDe1VKZnmFhrpQBSLSAKiCgcKQOVyfnacs61QKCwEJcLSD+lXYf1T7vQQlsBjVUFeED3l7y7fbnjm1ui//Oz/tu76Vpo5P9e85oId5zxbj6zXD61ra2n2L84QWZdK8yTbesWa5AURnrll46ahvm/u/lnC0q6QF0QE6rncmOaCTU0cCyh1dr6ZG729Z3R1mhe8f3Jqamx8VV1aWjhNSenBUSOnJ9vRHiIANNbriJ+1qUKm9DE0/BhICSejeLazQyfnj2IhvweK/qCvL1PsL8aJxMZxNUDF56eaNcBazuWnYSO10rZWy99R6bdfu8u66eaUj3HYq3nPOcNJ4oz1WvFMw8gaGmCDaGF8wnImoLYVc7+luzjmFYDFJWt2doWCOomp2QSA6rmwaNN0W5u9uM1S4dWZY5M1O0dxCNkD0Ls2PfIyXsK6IU0pc6+1BU4stFffnjwsm15QHPyTr8zk+1M/FMs+gYsD7rWgWC5v1bwfsDoMbLU2u1aEHt5jVQLuvZy45m6eZxq2cI/9gPIqinMZL68Vs7hEjPh6udhL1JcZ5UtAM7PJRmx5ZTtoBmBbZvZr6iG1Btk1Dp06Ewtn6kCTgLDcBsccXI8I3AMEbyj6vNqbpdNeivOAuB6fVT4PEJift0eOzlel2d9ae5grLvtLBuyYB9i8ROPori77u1bTlYEKJPJZKZZtBsC1USFZ26C6ewVA7DhrTzfo5RQL0i4/nwYOpWNFuaXFXsvzzDDo7Yj9TRbI6MNSs5ib984wSBj8HvHZO+sbqQFDg4MaDs81oQEVxTWvueDlzznDT9YqGhCm6NCAip8Tzo0ACFq13vjGMlmLyVFfn+liE2kA8alVZ5cjLqgkJh3oX/6hsdKSilCBhfqyJXVnh9Xby3Dcn0prb7frWV8sbyaLRbBsjP0vf8lz33TBObLqh2tAT2dnZ0cHL1lDA1gUfcc5z6ZH5l8Qi9QA+Xyu1jXAUtjnhwCsCsBfvH85g7479Ko8PT6l0ToVKL7o34xJrFRJYmrB1/Rvxr0RojPB/vTlp7YKsf/2p23+yFsujQ55kAaI3PAkyBoaYD6fIyKmIMTVAJXVvJrWgEf22Mu2mzdW6uHmTQDe9U4LUBlZVIL9O1qa//nP3tzUoLS94dEA98kgaEDW2L8chJgaoL6XU9Ma8NMHKqgB1SsAMzNlD855+7wD50764qKdSrV8jMKeK/AmPFlWudi8sT/hI2955ekj62JMvVY0wHMuFBqQQfaPqwFxd/KhARXRgGoUACLQI0fLeVTz8/b3qWlbDMSWryH1PzVqb92MT9gF0tfJMfucXnMzgwxMTNglHz9hixZVnupMZWrc/vrxVH2A3Ys/7/qD34v7KmLjoYGB5saGdMgaGmDC/uoaMNjfr7GTDw1IXwOqTgCI/Q8eCmBA2zN50hYA7amA8I6e8iV3zs3ZGZ80gDUZthP1E+m72yj9mzSAwqp+Eq2i3rPXv/t1nW2xHdNonNjV1UmMXAoSLWhA1thfRQN6Ojt7enp4yRoaAAFQEwAa+0vGvzOzdnqPHlMfPRZ6Asu2wZvVPzRw4ilrPOR8r32kpU4pbbSi7P/y7WdesO1p9cViXV2M2DqrBPX2WhA0IB/sL9eA/t7etpaWJMgaGiAbm87O6i1HV5cAEF0+JTX4tBtrnZ3nExdUstzgkxqW3vSCpiwkLfK3JmmRP9pK3zvx4Tdc2N7ctFCaV9cAzxoxNCBH7B+mAc5eTkJkDQ0IwMSEdejJ8nJ0fAqqmACIPdSYvS+KWVRO5+vtjqqUrHcYOtI2LtJlu9Ls/4JnbFnX0yn658zUpP/+v0j2F6COLWwdA4KUgNG/VQX3B1SO/R0NoEdGOmr5HJ4TMvqv7P0Bl593Thr3B1B3FtahKjTqPhZO/y7lYeRBhHbgCY3bDjjS85MLkF7JKsopcYHOwJ1zv7/WHiBSAyT5IdCAHLG/WwMG+wf8dzVDAxLXAD/n5EMAZlenL3F6H4cAFApW7lCszyz7t7c0veDpWzwdSaIBXZ0d8vwQaEBFcPVl579029P0XjvY3z84NBToswYNSFYD/GyWC35zGICeQpw1q6jPVlRYUdLz4WlU8G/Q6+0qrwqsczbum37Rbz0tsCMFakBLc3NfT7TDEjQgffZ/+fYzJV6tkfM5idcmNMBIA+5/QMpLjWuyBIkoeK1DkxrRFm3rGtvpuo91CUglF7Ndy+SHSpafIRD+PDrS0hihSfRb/1vvO2DfAJUBPPeMLeKap0gNsI3eBlR9W6EBKbN/ef0gpga4V/OgAUlpgLAMCp1/DdhWYN3d9neN+2srhe4uu7Yx5SqK3ImF5RaewpNHD3KxovfVnnxRyWGvDRPJG75QkbO+fmx/2uZiQ6OKBhBZFOKECBqQMvvH1QD/Xg40gB/Uzb98W8Tf0Gia+LSz08oRVi4kYBUAQfFhTC35lVJjaQ6+7FhwtMmtzTTAD7x5hn4yvD5g+P+je1O+BCoMHS3N6/vsq+0jNaClubktPglCAxLFB15/8St+57f8P1fRgLCdfGgAPx7eo5oUVO0onuiN1oAdDR27iDrHxlf3l+2rfdsYrqmkEkY22Jo8NV2+Vae5yaZ+840XcbEBVdjJNyW+CFPIr92VkeexdWR1yinu8/ITh9CAjcPDem8hOqe4591P1hb35e9WFdwprwaR8xO2WyOOOASKuhV5V/OyBgSyZ0KXv1f/nfLU5V/4PAiAspMPMT7jtfSe8b5wjU4CKnvi4h6J7AmARAPaWlvnZ6YbisWC1qkraEBC7G+tJHHG0gClu5qhAbygLk8dn+P6xiwj8n7KogVkaTLY0eqdVAVqQHdnp2JHggakyf4OWatrgLrHJzSAGff/LAkBuEO+w5wx5DCFnx3ZWP0XGO7tDlDptfsBzU1NxeWeo7ioKtEA7AeY46pXXeA/7eU+0OvXAEfOY9/VjP0ARjyyB+QHAbCsvRlSbLEDLNeATtdyGTSgshow3Nd9+UueG0bWcg2Iy/41qwEfedtrqr7jQwAqh2xkf0ZCaEChUGhda70HDaigBqzv7ZKTdZgGdHe0N+h2vlrTgLdfct4zt2ys2Y4PAQBWNaCnp1e7I0ED0kegBgiXN4pA4B4MNMCPV5y9Dd0fAlD9OHT8pPwPOjo6A8kaGlARDbj/0b3j0zOxNMDt8QkNMG+6AASgenDwxKj8D1qam8LIGhpQEQ346y/dqT4P8N/VDA1QaboPPbYf5AABqPmnVSgUl48xQwOyowHff+BXihqwceOmzqBL7qAB8qZ7z0N7Er80BgIAZAH379kr+W2Tq+dAA7KjAXfufiBSAwb6+jo72sPIGhoQ1nRp7P/6D30WzAABqAkcOiHbA2hc66ENDciLBjgZnxKyhgb4my6x/46rP3FyEuk6EIDawMHjo5JNRb/3JzQg+xrgyfeHBihqANgfAoBVoLVPK+h2eGhAljWgr6fHf9oLGhCpAff94ldgfwhALeIHD4aeUG8KMdKBBmRTA4rFYldnR1yyhgb8cu/BV3/o82B/CEAt4vsP/IqRrKEBFdSABumdd9CAwGKJ/TPl8g0BAFLF+PQMNKAW8oKgAf5iwf4QACB0FWi+VIIG5EgD/vzG2xcXF6EBisXuOXgM7A8BAGzuOHg84EhwaaGEeUC+NOAd192EeYAKHnps/6v++jNgfwgAYOP6r3/Xf52IIVlDA9LXgFu/uxsaoML+yPmBAACr+Nf7fvn4E4c8GjAzMwsNyJ0G3PKdH0MDwP4QACAe/unf/8NzrWDkHgA0ABqQLw0A+1cW6d0JfKKXQWx2jC/tml+qkWfzb/c//Pvbz3z2fxtxzIRLpdLi4qL/PLCErK2gi39xn7CV+n3CpAH0/TNXvkmFrAMVWqhgmPpqF1vB+4TB/pWfAfSeWIz8qh3OzRo+evt3xqdn3POAaeVVIMwDMA/I8jwA7J8F1Fl7Hqn1GcAb3p7lJ/SCZ2z58M4LHUP5jva2gb6+uIWEEYeEFEyKlZCCCiTEkUSxKeeeX37+OZHzALlCS9TXpFiJ+qogTKEDi80K+3/xc9VNdJGVwR5A1rHrF4995Z6fUb8V84BJLZ7CPADzgOzMAzD2z9ASEEKQfXz6zh/92/0PCw0oleahAdCA/GoA2B8CAMTGR2//zq8PHRMaMDExzkvW0ABoQDoa8NB/7QP7QwAAHbznhq8KDTh69Mjc3KxeIdAAaEClNODnj+2/GOwPAQD0MDE962jAwYMH2ckaGgANSE4D4PIGAQDYNGB8YmLs5Cg0ABqQCw0A+0MAAGYNOP7UU0mQNTQAGsCrAWB/CADArwEPPrbfPiIGDYAGZFgDHn3yBNgfAgAkogG7f7FnYbl/QgOgARnUAJHxCfaHAACJaMA7rr+dNCAhsoYGQANMNAD5/hAAIHENeNs/3PzTPb+BBkADMqUBYH8IAJCSBuz8u3/+2a/3QgOgARnRALA/BABIVQNe97H//cu9B6EB0ICKawDYHwIAVEADXvPhG6AB0IDKagDYHwIAVAZjU9PQAGhABTUA7A8BAKAB0IBa1ACwPwQAgAZAA2pRA8D+EAAAGgANqEUNuO8Xe8D+EAAAGgANqDkNoDZ22d98FuwPAQCgAdCA2tIAuLxVAZQuhb9k00hGqnvPkaPHZmaZC832pfAmIG4ihiKeSujyd9wpb9XqnfLpfOp1PZ0veMaWns6OHzy4Z8+Bw/xvgEvhoYGYB2AegHlArHnAIweOpMD+L99+5q3ve+O7LnrhG87d/uU/f+vHr7iso6UZnRozgHzMAKixXnT2WRef/aytI0P0v+PTMz94YM+dux+4/9G9mAdgHpDfeUA6OT/E/ldfdv6q+hbqqbb/8v3//xNf+XbGZwD5Qr31rndG/tEZXZ0Zqe7+yamp0gJzoV+7i72e5z7r9M9fuZO+93W2i580NRRJCUgPOlqb7/3lf6UZtNn50p27Hzz3rK0DXR2l+bliQ0NdQWfmV19fT/2wND/v/1Vixc7Tr+q1pIUqQ1WiiqVT7EB3B0WY4kzRTuGZ/vyx/fuOHL/w7G2RA3Yi+lJp3q9YpApLi4vFhnhCWBH2F0q2UCpte9opN37zR5zv9MqLalwAsATED+J9yXT18pc899qdO7AWhLWg3K0FpcP+NEj6y9e+ImDutbhAtX3OaZvAMBCA7GK4r/sDOy+W/81FZ58FDYAG5EsDUmN/6j5NzS2BUxPSAPoCyUAAsosrXvEila0qaAA0IEcakCb7i3+HaQAAAcg0XnzW0xT/EhoADciFBqTP/tAACEAu0d7SVFxaUL85jzTg5qvflnJyGzQAGqCuAZVif2gABCB/OG19v9iqUteArSNDn79yJzQAGpBBDags+0MDIAC5BDQAGlAFGpAF9ocGQACgAdAAaEDaGpAd9ocGQACqUAMKhUJXZ8fI+nVbNm+ir1M2jjz/WU//wp+/FRoADai4Bjzw6OMX//nHs8P+0AAIQFVpQEtz86YNw309PY0rhgSkBx3tbeduP+srf/NuaAA0oIIakI6nRVz2dzSgUKgHsUAAcqwBba0t64cGCyGuCb9z5mlf/eCV0ABoQEU0IB32P224/69er+nBEPi8AAhAPjSAeH+gr0/+99vP2AINgAakrwGpsf+nrrg01g6ZA5ol0+wZlAIByGo0C/WBU1RHA3q6ugoKjmnQAGhAyhrw2JHR1Ni/vbkpbpaEYP/IwRMAAagkqCMRSUk0oFWZ06EB0IDUNMDO+bnm71Njf//MGOwPAah+DSACnJuZVh/1kAbc9bE/62prhQZAA5LTgHQyPj3sH0sDwP4QgGrQgMaGBsktJYF45paNX//oVdAAaEBCGpAO+28dGbrxvW/sbG0NmxlLegTYHwJQXWtB0ABoQIU04PUf+qyb67+5+2fpsL99yLG1Rb46GtgjwP4QAGgANKDKNSC1Z0qMv+0t19BU4GM33/nid3/QowcJsv/yVlbkDpmnR4D9IQDQAGhA9WvAB15/cWrPlBifpgIkAA89tj/p9/IbnKhrANg/HRRP9EZrwI5DT+yaX0KwtDWAWrb/JiOhAWFcE6YBKczZ/Rog7pQXtdW7/F1cwu43HBYawF6s80O9y98FWQcqdBLFvuXlL7j34ce+ff8vqqnlh9lbyXrEsgbQb5uamvp6esAeaQgAQpCaBoTNA6AB0IAP7Lx498OPJZ2IWXH2V9GAxdLc+o0jKsdlsolLNo2YF3LPkaPHZmaxBIS1IKwF1cRa0Eh/z3svPb8W2F/eIxobGgZ7e/XOCQMQgExrQEtbW+AgFxoADRALQSMDuV/3UDc292sAsf+6gQEa+8ftEQAEIBcaUAhb6IAGQAMI7730pTXC/n4NcNhfr0cAEIDKY3x6JrLFM2rAfTd88IxN66EBVaMBr3rh9vxOAvQuNRIa0Nzc7GZ/aAAEIJfYc+CwSovn0oC+ro47P/qn0IBq0oD//rIX5LHlnzbc/+m3X6ZnXdXU1LTl1C3FhgaVHpFm+gMEAIiNQ8dPQgOgAdrFvupF2/PI/p+64tLmYt3sTOwspsbGxuGhwfrlIKj0iBSOL0AAAH3c/+hexZkvNAAa4C+2s7Xlgu3PyB37C5e30vxcLA0Q7C9WflR6BNgfApB13Ln7AcW/hAZAAwKLfdlv50YA/B6f6hrgZn/FHvGNe/8TDAMByPoMQHESAA2ABgQWe/aZW3LR1LeODH367Zd5HJ4VNcDP/io94ubv3AOGgQBkHTd844fqfwwNgAZ4it040Jv9XCCR89Pf2xt4vFGuAWHsL+8R1331OweOPgV6gQDkYBJwy/d+Ag2ABmgX+4zNG7Lcwjtamj9xxavpu+SIe5gGyNk/rEdQ6/rkV/8d3AIByAc+8ZVvq6SEQgOgAYHFbtt6apbZn8b+6/u6nKarrgEq7O/vEeK2erAKBCBP+KPrvgQNgAboFfvMLRuzzP5bR4Y8TVdFA9TZ390jHjlwJIXb6iEAADPGp2c8GjBfKqWpAf/6d+9LmUegAVzFpmzyYcL+ihoQl/0Ffv6bA6/+4PVgfwhANWhAKUoAeDWASOTrH70KGpBHDehsa8laY5awf6QGFKyl3o72uOyfzn3FEICax5lboQHQgExpQNaWgCLZX6IBwuVtoTQfeGdDJdk/yY4PAcgP+pO9ec6tAdNqlzxAA6ABuWP/QA1we3xSBBQ1gHh/54cTv6846Y4PAcgJnrMtnbWgu3Y/ODGpOgiCBkADcsf+Hg3wODwragDxPo399x0+XgUdHwKQB2x/ltWa+J4bacC1X/r67d//yYzyTW/QgJrVgHse2pOFntHe0hSX/Z2m29XdM7xunX/dX64Bgv3T8PyhLk8dHwKAENh42e+l8z6kAV/8VmXOCUMDMA+Iy/6fuuLSzf2dOhEoFAb7+9o7uwKbbpgGpMf+KXZ5CEAuBOC8FCYBAn9+4+1f/vdd0ABogAT7jhzLAvuftr4/rsGnYP/hocHGxkZJ0/VrQKrsT52dujxAD6v3xGLk1675ar+Up7XFetsbU3u3d33qi7fc/WNoADQgVABSWAFXYH/xv7E0wGH/yKbr1oBU2Z9Anb21xQLoAVl7HkEUyvjy7da37k7t3T7z3jddft456n8voTkJ1wQi7f62jM7Wllvff8XTNw9LSEEFYQsICRVLIHloWGG0uJAotKTY13/os9/c/bMssL+DYkNjU3NLLPZXaboUgdmlulRbI439X3cZ2E6g3nrXOxGFMs56hnXsuLXvQDrvRj1801Cf+mCcCI56S6k072cT+gn9vGF50q1SVHNjw6Uv+p0DR449vPdgatGdnS/dufvBc8/aOtDVQYPKYkNDXUFnBbK+vr5QqC/Nz/t/lVix8/Srei1pocpQlahisYq96jNfng2qSdLoaGn+3Ltft2UwwIt0cXGBmlmx2BCX/eVNd3R84tIPfPrnv0mp01kvfJ71pteC6iAAIdi+rXY04KLnPfu/nngSGpA1DaCx8Oe+fnf6bV9kfJ6+cX19sbhQmo+lARL2lzRdZ20wPfZPcaUXAgANyLQG0J9BAzKoAV/74X13//QXFWF/kfFZV1eIpQGR7B/YdMH+EABoADQAGuAt9qrPfvnIU2OVYv+VhqGqAYrs72m6JyenwP4QAGgANAAasKbYfUeO/81NX60s+6trQCz2d9rb1Hzp0r/6NNgfAgANgAZAA9YU+/Fbv3nfr35TcfZX0QBqXJs2bGiMmR9FY/9Lrvn7Xzz+BNgfAgANgAZAA1Zx4uTYn1x/a2r5Pyo+P2EaYJ/17etrKNYXG2IIQNr5x2B/CAA0ABqQFw24/s4ffP/BX2WH/cM0gNh/3cBAY0PD4sLC0uKiogaA/SEA0ABoADQgWAPGpqbf+Y+3UDTSCftH3vLK7Vs3K7exVQ1w2L+8FqSmAWB/CAA0ABoADQjVgP/71n/b/fBj6QT82p07LvjtZ8Sr7bIGLC0uuNlfUQPA/hAAaEDONGD/0RM/T9ErosY14Jd7D/7pDbenE+r3/+HLL3n+s7WCUBwZHg4Mn0QDwP4QAGhA/jTgwrO37TtyHBqQggZMzs2/6W//19GT4ykE+erLzn/Zc06XmzoEQmR8Njc3h+1gh2nAqz/wD/f9KqWZDdgfAgAN4NEAAjQgHQ340+tv+d5//jId9n/59jMtBWOfQPYXGZ+SLCa/BrzjupvSc7UD+0MAoAHQgHxpwC13//hjN9+ZJvuXyVpZA/ynvRQ1gNj/lu/8OKV2A/aHAFSxBpycnDpv+29BA6pMA+jJvvVvb0yD/V/9Ujf7q2tA2FnfSA14z2duBvtDAKABPLjvV78hFiYuhgZUjQY89Nj+nR+6PoVjX9fu3LHjnG1xDT6tKJ8fiQa89/pbbvveT8D+EABoABuIf6EBVaMBxP47rv4ETexSYP+Lzj4rrsGnwIZ1Q3Knh0ANuOqG277yw/vB/hAAaAA0ABpQefZfaQzxNGCgr6+1JfreRI8GgP0hANAAaAA0IFQDKsL+cTWA2L+jvU21ja1oANgfAgANgAZAA0I1oILsr64Bsdjf0YArr7/ltu9j3T9nSONS+BO9hSx81B3jS7vmlxJ8gxu/YP3o3tQ+zuXnn/OZK9+k/veMd8oT/uH2f732C19L8/FVwZ3yFWd/N9dTbQOvql8/tK5/YCDuOyLjEwJQ8wJQYxrwT9/43p9efws0QFEDHjlwOCPsL9GA/t7e9tZWkiuqMNg/y2zGRWhZ+TBVAmqa1EDTAvU66nsx1D6c4EgVSBsCh4RheMuFL/n4H1+eZnSdW2QlSqaCMIJLqFjCTx9+NFPsb/f8Qj3V1i35gv3lSoaxf5UBAgANgAYkqwFUW6pzptjfrwEO+0fOZsD+EAAAGgANUCpWsD/VOWvs79aAgb4+N/sragDYHwIAQAOgAaHFpsb+yz4/Z+i9dmhgcHBwKHD7R6IBYH8IAAANgAaEFvvrw0+lyP5nzs5MB7oyyCEyPiUpAIEaAPaHAADQAGhAKB56bP+lf/UPqbG/+HdcDXDn+6trANgfAgBAA6ABMvZPJ+fH4/AcSwP8p71UNADsDwEAoAHQgMqz/0W/e9bv//bT/T9X0YCws75yDfjQTf8v2B8CAEADIjTg0+95Q21qQGrsf/HZz7r2DTs8ifyKGiB3egjTgK/86P6//8q3wP4QAAAaEIHXvfQFn3nvm2pNA9Jk/w/svNgKOswVqQEqPj9+DSD2v+rzt4H9IQAANEAJl593Tk1pQPrsX+7AcTRA3eXNrQFgfwgAAA2ABoRqQKXYP5YGxPX4FBrwlV0/BftDAIAca8CL3/1BdW6CBsTVgMqyv6IGaDg8E279/n9c9blbwf4QACDHGhCXoaAB6hqQBfaP1ICO1pbmxobYQ4e7f/yOT96U0jMD+0MAoAHQgHxpwAOPPp4R9pdogHB5m5manJ+LcUYM7A8BAKAB0IBQDfjF409c8v5PZof9AzWgt7vbcXlT1wCwPwQAgAZAA0I1IDWXt1js79GA9ra2zvZ2969UNADsDwEAoAHQgFANSI39L3zuM+Oyv6MBAwODA729/l/JNQDsDwEAoAHJasAXr3l7R0tzTjUgNfZ/+fYz/+el52oYfBI62tuGBgfDTB3CNADsDwEAoAGJa8BF5zznqx+8Mo8a8MiBw3/4kRvTYf+rLzvfim/wKdh/oK/Pkhr7+DUA7A8BAKABKWnA9jO25E4DUsv4dNhfIJYGOOxf7t5qGgD2r1nUWXsekfz6kk0jGanoPUeOHpuZrf4HcuMXrB/dm9q7PXPLxq9/9KqutlbFv5ewp4RrwnD/I49d+pfXjU/PpPZ5O1tbbn3/FU/fPCzRs0yxv4Om5pZiQ2Ms9ldR6ObWtq/86D6wvzpO9GZl0LxjfGnX/JJhIRAAaAA0ICvsf/HZz3r/H76MhvyBv5VrQBj7yzWgpnx+wGYBfRaToMwBa0FJIu5aUMpnfYniiegD/0CyFiRn/zBthssbAAGABkADFjLC/uLfcTUgkv0DNQDsD0AAoAHQgFANqKDPj7oGKLK/RwN2P/wY2B+AAEADoAHBGlBxlzcVDYjF/o4G/NeR0bd98otgfwACAA2ABgRoQEY8PuUa0NzYEJf9xUf7g7+4LoWjDGB/CAAADYitAf/fh9+rnpLEpQH/9G+7HA343B13p8P+W0eG/uRVL5X/TZgGtLe1kVLGMvhMU9jA/nkB0kBzglrKDU2Vp1w4+8wtux9+LJ33Ivb//JU7Fac7pfk5d24osX9/T4/4d3NrW0NjI9hfBWAzzAAwD8jBPCCu/HAhm+zvmQe42d9SNnkG+wMQAGgANKDyiMv+bg3wsL+iBoD9AQgANEBHA7a95Rr6Dg3gwmnD/de/67V6G909PT0jG4IXMSQaAPYHIADQAE0QcRB9QAO42P9TV1zaYC0sLsa2ohMZn2HXk4VpANgfgABAA6ABWWH/9uYm+vhE1rE0wJ3vr64BYH8AAgANgAZkiP3F/8bSAP9pLxUNAPsDEABoADSg8ti6YdDN/rE0oK21JfC0l1wD/vNXj4H9AQgANAAaUGn2Hxn6/Hvf0Nfd7f9VpAY0NjZKzvqGacAv9x585V9+CuwPQACgAVWoAWdsWp8n9l/O+Aw70CvRAGL/4aHBQkHWQ/0akNqVxWB/CAAADaiABtz8V+/MxTzAk+8fSwNU2N+vATXH/nNz1syM/ZU7TExYMW08ZFhctMbGrCNHrScPW8eO24Uro9561zslvz6jqzMjEds/OTVVWrCAQGzfZj/4fQfSebfZ+fmv/fC+87Y/Y6inS1EDiKdKpXk/19NP6Of0W3WviO72NnprqgBVIy/sXx5t1dcTpy+USv6/XyjN1xeLdXWFWOxf7sN2sfUP/npv5tifPumJp2xiGj1pf1HdaBzQ0MBQgakp6/AR6+SYNTFpf42NW9SymiNOV2SIzfY/MXX0mDUzSw/bUr6XNBiC+im21B0o4KQr9G+KCZVcLGIGgHlAdc4DPnLFq/PF/orzgLjsL/DIgcN/+JEbs8X+xEQHD60ZjdJPiKpIEgxBYx0qx62jNAQeHbXfLl+guQuN2U2mAhRM+qKP75deKllhblQDAkBRoNEH+zyRCnTmXEFjOv3ZHBX4+F7768ATtrxDA4Jw+XnnvOLsbfli/0gNWJyfG+rvi8v+Wcz4pGZMXcNPTGLEOmVQVXpt2BIHMSn19HyBQqStiERBcn4gJolC0apurKyInXjOqeaF9Z5YXCPd7kY5vF5lwhUNEhVHq8QMmtCpPHUVnTMt31ChAV//6FU0JFfXgEDfUKEBsXxDP3LFa765+2f5Yn9HA6xlT3/3DxsbGob6+2enJuvVrqp3P4LM5fxQpwtkfwGi6VbdXRw5xRMhdnZYhVyNa6m/k3SpWbquDfJkxB8QgRA1SUMdwVl3eJaVxbSC4svFdw7rOYMCKnZkA0+xFNY4+yExMDbulXFql/19DBX2z1TovTrjrF3WjAZsGuy7/PxzbvnOj/PF/oEaQOy/bmCAxv7CWLtVTQMyyv42qc1GtHOTPiIfUNMfNDdb+cLUtI4AqEyk5uatVq4ZgLPhTlEm8enu4vv8U2tUi3F6lRD8lWSpdmCFNUquGQ14+47zMiIAGh6fjgY47O+sBaloQNwluPTYP9GuZ4A7JFkS9jb1aMTru7t1SE9tLb5S/BZnrkS66khrYwPnJ3FPUhgnFsnNBP2VZKl2YIX1Sq6N/QCSnE1DfRVnFj2HZ6EBHZ1dbvZ3a0DgBTs5YP9Eu15CUCG0Ql22WIij5JhFDA5YvT3WuiH9JbxA9PeVpYXIjt6C7aE2Wu3tiYSeBgLu6NO/WeZDVGH/7LW3R7O02tCA3zp1Y2Wp47Th/uve+gdtTQ1aD7xx08gIxcH/K4kGZJ397cFiU0Q7N+kjck7UK1zlVXqk19rC8zd69YkStpgCQPHt7ORfYqNiSVRO2Wyv/ps0jkBpGV5vBR3EN2VqKpbUhUJBAaFqc01cSP+cFX8KC9XfRGtrQAMU152SY/9PXXFpW3NjXINPy5XvH2bqEKgBOWB/AnUNSY8wGS3JX0t9R29cTLWVDxapG+r18cgXEofokV5nR/SHimKPGkgDpeAyble4g0vsTLpFI3TGWR4VRQWSFtLXpo0MM5hayg1NGe0tTVdf9lLh8hbX5NmT76+oAflgf9GMaSgT2C+oeZuMaei1YZ2Cfm7S06liYURMP9dO8ZCEwhnk6TNbd8T7Mi8BAXlEVWtA+nfHO+xPY//T1ve7yVpRAwJPe0VqQG7Y3zNLdj4mcTcNmDqNj+MSYxK1ucmaRmNEhYZpeGIdwjOHEGse9HOTQR5VlUrwqwuN/Q3TKUnwApeIxWdRmFjUWXseqQUOPNHLIHWr5wDyiBu/kFpeEKGrrfX/+Yv/8fxnblX8e8mSN2mDJC+IOHHXQ79KOZYdLc2f/h+XnTrQHahnxOOFQn0s9ncwPzdHKuL/+fj07OUfvTE37J8ORNInEWiR+zyTk7fDu9wtfBqs5f1k7ZUfP0olO1ncSZBtbVmjuxAACEBFNIDwmfe+6fLzzklUA7b996v3HT6e5oci9v/8lTu3jgzNzkyX5udiaYCK04NfA8ampl/z4Rt+ufcg2B/gBZaAsBaUIN7xyZtuuVs1T19jLWjfkeOVYn/6d1Nzi8jl9ytZ4FqQos+PZy0I7A8khyJCUHMaYFlpzgNIA6xl6x51DVA/I3ZPuos/bvYXEK4+/nmA0AD3PCCWy1vD8uIAlVBz7D83Zy/saGdzhkEsFgnHBfpizNpwVnXE2gtXtanCU1P2gepSabnODWwZ7TMzdoVX1osgANCAHGvA5+64u4Lsr64BGh6fpAEnJ6cyx/7CvIy4SRxDtdOgO3hOBRExuX0VxdmaTg4D59GTtkeQ+9wsFes5yqMBqipV2H3Kd3TUDkh/n+mexMTEGo9P8Rb0KTxb3xqiQsWudcfBElD+IRyEYp0Lr4q1oHse2pPSpmg4+zsaIFkLKtbXazg8E/v/Xx/4dLbYn1ragSfWGL0JT1xzD04q88nDXodnYqtjxut7VALxsqd3kB6EmZWqd7qDhwI8Hugn9HMTYxgKBdU50OGZSjaxUQq6KyafMwAxoeOdyiUKanBj4+XZXG8PW2qBMFh3WhuNa9SPDed8HjBfV/+O6/45C+wvnwfQB+lua7FinmbIaMZnIDGVR75N+q1aDKXD2LCxQX8eQMok947WPmYfFgprxdF93RBzKASov+t5ZVIcgszjlgmUhCUJ8yYhs4H3FRgOFvbtt0um7wmZffKC2hkFQdA0NTsucyhhue4ea1DAY3mL53ke8L7rv5zO9q8K+4fNA2jUv25ggD6I3NgnH+xP9CEZfppMAiIcnseNKEj+W72hujwU1orDs06Foz6scHjmK7lQvp2ShIWd/YmMxJUFx1g7qpvjJDqcIQEYlX0EbTjrsB51jIV8asBVN9x2+w/uyxT7+zVAsH/j8g2IkeZuWWd/a9lYWE55JhNZOeXpkanYT5ZDr9pzCneR6t3OpvJJ5+YZSy6UnbspEIw+zJ5aMrqhUiU9D5XxbuUkEPjZWeoceEOyhhzmSgPGpqaJ/b/yw/szyP5uDXCzv4CKBtSow3Nkd9B7a5VX1fw140V7N5xYtVBgPk1HxTpDVO2FtoD6Fu2qOo+W/p3xyx+oeu4KC7BkTRSDzprqbYrkZD9gdHwitayY9pamz73n9XHZX6Clta23s73Ot+4fafS/80PX16LDc2NjhAbovbXKq3ht7de8e52VByzz/rohThNmh6mFDefIBmZP5v6+8qMVvmnZh6eSXN7RFFV/Tph2yZmfB8zX1afJ/p+64tJNve0aVnQ09h8eGuzs6m5oDM4LCpsHvOO6m1LytNDL95dzpcmYRj6GIybRdniOHNTqDR/lZtdGJTebPoiYD6jeetc7ExOXQnn8ywuaVnd12SX39FhNTYovel8LgyB/bHpJsyFSbReXLBr30T/6etlOi7S1WbNzq2t3JLddBtKyfZu9pyK5NYkb39z9s01DfSp+zjQuPvfdHzpw9ERq7H/a+n4i64VSqdjQoH5NsWD/xuXnW2xoXFpcDOT60vycXayraxD7p3S1mfZpL+p34lxSIKhVay8hUMkTk6GJUjSmUe7mAZgOX3/u7NTULfqkklAIHtfridRyxidkOWN2GmGvTslEPkF3CCcpAImCnkFdDE6vpACI2hJZ05idGpzyfd8qA+NymVQ4NYuWFtMCM6kBxP6p3Xzr8fiMpQFu9i8/djUNyAH7O6NI4lP/xzG8tYKCQJ0icNeUmnePwSyflKO0ELy+RBw90M8fCsHRQ4Ox2GlNjyY5DGvqwuFZj0CIgoJCkVsBiIkKC0CioAYRUw5zpAG33P3jt/7t/6oI+8fSAD/7K2rAO//hi/lgf0FPNNSg9ra0nI4h7hsh9jcfeVDcqChRrBj/0k9oVtFlvFgq7mOZm1/dh6P/pbG/oXe0CMXCopdSSbFIV0yWPUgASJxohuHZOKSAGJ4EplAsLlmzs2s+h9wNlMVEc8f40q757F7roY4ashRN3Tf0fa+9+O2XnNfVtmYg+bk77r7mxlvTqYDI+dnc3xlo8Fko1De3toVpQBj7O5iZmpwPGoemltEEl7ekvKMXXRrAezTVTtCftwu3jaMb2G7hJYkdPemsX0EAIABZ0QBi/8vPfx5NBegfux76Fc0MUnP6dGd8hpk8h2lAJPuHaQDYH6g4YAYHhCD13NCTk1NpmrsFsr8VbuqwuLggzN3cGqDI/gTh8OxoANi/dodWEAAAGpAd+E97KWqAOvt7NKC22D+5e7sSgrBbWFyyc/m174IPxMSEvRMrtk94V3UmJstnTu3cyyb1G8EgAEBNa8C1O3cEnvaK1ID6ZY/PxpibcvTCKz97S7bYnwh6bLzsbyNStzs7eM5XUoHCD6ZMNsvHTnlPBXk+iOESvPBxc5vtUP0pFJJb3RXhMbsWEHfNGyaFUw09lkdU/9GTiqlZsIPOJBYXE7G4oGJpDEKNI5Y5R+pnxNJk/4vOPivst2Emz6QBczPT6wcHGuN33Xdcd9Nt3/9Jttj/ycO2XZVob+IeEvqJuc0ileMxTBZWl8cS29cxdHgWofBbrdFHMCxZhNR/bkBYQxo6PAca3lFtjxxVsY2rgRmAmHYV6xMcevByND05ZzYnbq7gioPbmTXWuKYa5wFy9pfMAwqFwmBfb2lulgSgLk72bRbz/amxBRIQMQsN2LXnAWIoHdYOW1vYVj88fGro8BzGxcIuU8/hWRIKp7/rOTwTS8h1mt53JOIobjZmAEIJH99rXzfBO/IVIw4a4CQ69OAdxTiDJmocVHPz2zacwZd7FEPvkm3v6Iqzf+A8wHF5C7umOE/sL64SCoOJD7P70hg/WJp0cJ3HNIfqkTbL2g7P8lBY/A7Pa9QlquRsCICzUEixYDSmpgfmVkhhfJ1lBDYyljsPgk6BZ987uuLs79EAj8enugZk9Kyv3LJ4yuDwnbzkRLuhXuEqi6J6rsYzswp1nk+qzlF2p9kQAM9CIeNySuRPMoXAz84SEK4ul38NiMv+jgY0NjV5HJ4VNSA3Tg8pT/ozVbKKL/Si1mGm5DhHpeSoaGRjD6C9fXU0ymjv7M/fyngiWuCmIotzXHNTwIAuJ97RjLjmNRdc+LvP1Hghjf1P3XzKYmnef6DXf1V9bthfbllskvcS+VouP0Sukov1PH+jwkJxcMmmkdDfSX61FneEO7tkYwbQ21NOXG1t5TSmttPOulf/l/6dfQHw71RzeUf7+6T2Vav5nAdcfdn5L3v26TNTk3FNnp18/+bWtkCT57B5QNbH/vKdWJN92lapO1Byd3hQI9cTAJUPm5x3dGtLpTpFNgiRHpvtzdTHX7Kdd9xWPnmRi3MoFAeqp9jLon+QNLLkS1CE1w2tyWYzzC/K2zyA2P/l28+0Qg70ymGv/KzQiudAr2QekIOVH2GLFphHaHhrBQ04XIYziYxpAkEfR/v2mLBQOCXrEYg8FEJXkpsP5UMAkv2I+TmC6HSPJHoINbKRDfaaILVFanPmMcmPBjjsXybrOBow0NfXvHYQp6IBH7v5znys+9MIQ5wO8Q8XDFsITeUD0+dpiJPQDICo1qTjUCjC0qKo75iUHBYKa8Xjs4LsaAG1A/YbNPOgAde85oKXPft0L1mraQCxf0d7W8CgTaoBd/zHQyQAOWB/h5HpM46NlxlKnAQ2d7UUAw7njLE4VUAlJzfa7TdeQiDZo9G6O5eU5SwOfeTh9XYetkddSLFIdQqVXIeHAADVrAHX7txx4e8+k7ieGD+uBoSxv1wDbvv+T676/G25YX9nFSKJUblYR0puwSe5+Tc9VmEswSVX4uZdmnyTBohzqSyzcAgAAA2QsL/I+CSyjqsBcvYP04Cv/Oj+/LE/EDhmT4Rui1nzI4AXEMCkARnLC3Ln+xO/E1kXCgFpfEIDPAk8KuzvaICTFwT2B3IHzACAKpwH+E97CQ1QmQeos797HnDL3ffWFvvTvKdyuSux4ay9sDs82zscK+d4eR2eqeSpafVkf1VQHMbG7fLpq7ERAgBUmwZc9aoLAs/6qmjAYH9/LPYX+Nq9D2SO/ScmbPoQm5nCh5mF9cSFgk7WUNIOz+awDbVOrsnvPPEUz+4rSaDfP47F4ZlqG8unSz0UjtHkihhAAPIP8UTZs12pk8/M2h2+tUX9fomKa8BwX/flL3lu2G/lGtDe3NTeFnsEd8vdP37HJ2/KEPv7+7l4mna2jxlTC9NGdzqjMBmkdtLfl9HeEei3LGzB1g3pa4A/FO6fU8naGkByNTqaWijyKQAr8xfmDCrnumRxAiuh9CxqfFwjJuFS65wxoekn9UOWalOvdkZ5RCUUFvU2XVENePFZW+V/EKYB/b29rc1NElOHfLC/YJDAZHZDh2dr2Ts6MJnd0OHZZqVkTgZQKCQOzzTK1tatsFBYK/7Pw+t1KWg0KdoJCkWhXOPF/FynKQY4pGb79vM4ZTrFHjy0POxddtmmfycUE8+VQyYV9twyIW4CYmkrnsDSe1WRd7R/T5jYv32Zv2KZPGeR/ak9SI6zGjo8S46zmjQ8k1pFrqVofyIJqKPJX0hUq+dJl6BRdnCQi+W7ymjYGCRZ+vcs0+cnDhWgAS/jDNF9hQXVnPqtwpj3EpW9lFM2yX/fG+6pJMPje9fU5EXPN4+B7e4U6DNOLV77QozVjjEZvNAk5kbqGlCJecAPHtxz1asuUNQAMQ9w2L8sdlJzt0yzvxXl/qhnaFyWlgX99zWps0mxkWM4CojGdFzFvXlqWmcViNELWS3IhfKOsHAISEhwWAa8zsfwNOLkQpZk3DlmAEtpf5a4oa7EPODg8dEbvvlD9XnAYP9Au2/tInIekFH2j+Qmk0lt6tzEMEU2VLUaQNE+nE0ErW11FIbWltVlBPMxqQOx7u8+qJ3xXDRPhTlLbgh6nhwPMawQjVBXYh5wwzdsAbjiFS+K/MvB/v72tlbiemL8QA0InAdkl/2tKO9Jk+aR3LHVxsben/5G9gfD63XanspmWGAnYkGhzsoDls1hiP0ZObosAK32tmF3t/2dN0vMsamiB1xRHyVVJJQgQRH29wqW5xiYB6meCJSBeQBpwF9/KcKNR+T7E78Tyxfqg86IBc0DMs3+zoBD0ma0IZcWo5KbI4RHb5BHr5KLlrY1lop7s15AkvOFDqlPgXmE7nmu3V38HiPCZOqUzdamjQkai7NrIX2n2rJrofNchaU2yzkUqqdHtOgnJo2kEhpw5+4HJBrgPu2lrgFZZ3/RDMKelKHDs9wvyKRkeq1EtEwanvy12t7RREFy5tE+a6Y9zIpEZ0fIEhCQApIz26I50OKivYrKWz41RCpwasreaaBRifk6WyXWgkgD6PsHdl4sYX+3BsjXgv7lu/dmnf2dZ+fP2iI+oqZiSC7C1tizZC8kx6SF+C+rcDO40b00raEu/4be0YGhcORBe9IvCYU5BQWFAgKQf7CbPDuUoX1lWIY1oK+nJ/Csr1wDvvDN7/3J9f+SA/Z3xrbEfROTNkPZzaOJZ+opcgXdZ4yJ7Ghoab49IAyTxQmGUqncpKlk84ZtS0jLmrMRos6GARFMPTYe4B1taKZN1aOS3ed7uCDONq09ZwABAFJEhTTg4PHRj//RZR0tzcVisStkLizRgFy6vAmThiRA1JmE9wNVOKHdMlKRdUmaXTvSwjUOE6vcbpchLogbEmlkIOpcKMANFEhdA1LfD7j/0b1/dN2Xxqdn2qI22fz7Ad++/xfw+AQiBCaJNV6awyUh4WJkQJMM+hocgAAANaEBew4ctjVgKvoklFsDfrn34FWfvx3sD1QrsAQEVEgDrLTXgkgDdn70hrs+9mddUY5vQgPu+8We13z4hrGp6cyy/4lehgHcm9uHzQu5Q3JIXjh3WRbzGHlxcdmSIQGH57m5ExxLRl4bBXH38sys/Q/blKlJxcXgDhX3Adu9ZnJ1zyDOxgwEAKghDfjF40/suPoT/3jlm565ZaP8L//lu/dec8Nt2WL/ubk1+7p2eky2T0EKmxmHmFju1y1L31Neh2cWJ8SyuemMte5U5lCQVlHJ7tweEoPiSbvOhrroCYUIO/1EzfwVAlBLELdMLC5x3lxhrVjFUbOjf4jDHxn2DX3osf2kAW+/5Dz6CpwKnJyc+tjNd37ujrvTqI06+3v6uTD+G9yc3cZGBEeU52kno6N2IzTc7HVb1boD8mTJyOFZ2EEmcWjfHwqnPz55WPOcsyQUzq8sK1ID4gsA9fNcHL9yYOdpLfFfrEMNjvqkcKU2vwIi/Q4pss3MswCEKamTEG1fYzRll6zYSCqhAQ7Fv+J52y48e5sjA/uOHNv10J5v3vsz+oNssb/nShMn8lkeaoTZx1I7NElL9VvVumdICTk8mw+P5O87skFzgiW3QxYTI2kfjykA4rqD3h7mDHHH116cbGIUGKqtiQOihP2pwu6YmFwBkdpk3B9zqrYhAi3X6b3U23SFfEOJ5W/5zo/pqzJPJNa6v9zWOIOwJ5qLsjajLQBy72giRL2bPMSdkQkNvOS6IublGjPySBttsU0iDXXMSAkSEfN9RjgLhcLrn1FXEnqontCLa+cy3SGng1WBpaubd6ds3x9QYfYXa2s5E4DpCMpbNPCZN/yDsCBXJBTlOs8nVecou9OCZvRnZplnAElMbJPrNv5Dehnvosl5+XKVXDsagIxPK3su7nn0hVbyuy6xCoCYTdgmzKw2qu4FJcb1nyQNbL0/yfi+SKCVI8sxwLAPrhH8WtAADfbP42nNyDpnbb1U7nWaaCgS5beov4lZuf4+e8+avhhzSKzlA8qkAcIsk9HhObnD5Z51RpF4m2UEugyybOQEekfTo9RT3+rWAG2H53ylXVhRtsaG/m5yttWLFfsF44qhUP8b9bFXHGEr6kQqCZFMyJJauFqyzzeJ3UY2LG/vLFnF+kSsUdgj7HGY4srIps8+N79ml5JaiImKV/RO+cyxvzPgcC5YzQWoVYyNhy7HmzQ8cYGVZCip3UGoRyRxIbs8FFbIxR6K42b5ZruCQUUNnAMgsk5iLUi0mBxBOEyJi1J5Y0L0RPMAsdnFcsKg+jTAcN1f5Oy6D1VZmV91FLbGfuIzzJkWl1UEptUT1Zp0SeJTCq88sVIPwjs6cBhq4h1NXZi6XmAorJULQiLLsICaQkJrr1Qsb8nVpAEsu75EfG6HSJZLGpKedA6vt6eGThoMl3c0ET0VRcNqZ/xr+/5zeEfb53KbotMrNZiaQnHiKa+6iFm4ydIThYIK94wMHJlUCDUEoBbB4iHjtTphR3VoAG/ODzFda64+vu2Pn8BEuTxwTmCHLyGzazEepwG7MyXi2nUQIwOSltKCXbi9Y9SkroW1IgBKnko1VpMcIO8agIxPwCMDCS3c6YoW7KCBzGtATvOCwP5A5oElIADzALB/NrC4aJ9unZu3M+u0M4kDMTe3uhWR/e0Ta/kAlzt3iOrMZXltmymt3AhWLEIAAGhA5dhf+MAQ5RUK5Xzimr2kb2zM9lNxJzWa75EKUTl2fE3m6OiorS6DA9kNdaDDMwXHTrdrNwqFJy+rVIIApDi6EdahSQyaqGRq09kf11grlo0rA5DlO7vVtjXzogHq7O93CaZOnnFXwdQoT0gCtZPh9ZyU5/DpgSfsvdMMakBgKBwls/SX+wNDUSwXna9xB30Msd/N21WoTOqBwu9a3dQ+1kMVF0lz5UUQg1DJzqAp4+Maa8U51akw6daRo4o3V+RDA9TZX9wQEkhYRHm5m5pTU9QmJnGBiaRLah/vCrSqdULN4obLC0koHCZRuEcseIIVFIrlgiS3ChjOvB7fG+GFrTdVPHjILpy+MxYu+p7ILLYvlzjM5u/mlnRhDs4SbWG57q4ktR72aLOPbvxR9WcxyzUgs3vCsdb9w55U9p1lg3ulQe78xGREfzeRJTnbZs2TTh4Ka8Xhma/kwvJJjSn+sw/OvQ1UPi8ruUujwrkeoce2W1zgyaVYcR+z4hDST6ZJnGPkHeDE+nmONCAW+zvX5JpHIztzO/ZW4fREvYCo2GhnLdQqbKZnXBrygArlzXGT5xf8fvNrqCq5dsY1Tl9civ4J1xNlES2W6mWl3cds01nTgLg5P/IGkLVhaRZYLyMNr+qw7MImbDh54fa3YzEdE2hsXLM8Sv/mWqkv1nt/wuIQSzX0L9ixHAYJdOTO+Npx2NqlRqizowEaGZ/yBpA770/LzPQ48vPqtWqVVyXnAp2TB1Qs+0yxo7V1+YDyZKxzyUoYHLBXjWkqQA+Y0TuaJHBmdnUJRdiIsqC/b801Z2IfmCXCVEPPHDYhU1XGIPsXxOg56oU6C3vC2vn+FIqw9bpAh+0gBLtx7NsfOi3u7va3vRPWQfMwvPkFBmK8cl/3HT+8J5jH4wiAy+ak0Ro8Va9GETYnNGU58EREEcR+GrpF4+a1PfqSFz3f/OnY7gNEF0HtLckBI31+xrG/exJgkhkmZ+rOjnJOFGMKkNBCcayDHjBjrjfpn3NdeKyUykqB2oPnnk5DFa+sBhg6PItkNv9w2HA67hlwuEOd8VsrwgKVNVAkqaNJVrY7OzVnLcI7Ook1MXr0aQtAHpFQCrZg5ySmdVRsxkf9ngrTdNOxtCzWa+a0ZUEDDM/6Ojc0uOWQ5ZIGCilpgCfhSrin5e6UGdU5m2MaqtiTpeCtU5Jw7S5JD0h4R7NfMSsagC/zGAIApA52S8v0NYDF6UFogJMRxHgpFQ0kxZRfZAqwXNKQxgSxe9kKYq681UdamNk9LWF2TfNv24aztGaOZXjKR6zJO4clGSFmlmtHBhAAoCqQpgbw+vzgwqJVAaDZT1fOKiyukaEvxucoNMCzWMo7MqAp+LIxAQQAgAZUjv2BKkBCEs7udBA0MoAdNFBdGpBobijYH6gy8UIIAMwDwP75gzBSFZsc7A7PJ55avV2La/tEVNjtSp0B81cIAJB5iJVQ9T3SJDRAnf2FW4s4YiocnhnjMDG5umPMcr9uHuE31GJ3eBap1bY120qmsqHAeHwbrRWH50qnOUEAMkx5vMcRLNe1GLyZo0RJIh1CEJM4W84Cd7cRa5eKWZK8GhDX49Pdzyky5vRh+RwbhW2kupGqpElYeTt4HObwfPDQ8gkh7jE1NW96RxObbr/vt6NkR47azaNyGhBfAKiJJ1RdMediHyyMjZcdnmnExDjhcriJ9wQWBYHahJNYJnK6Waq9xme8hzPC1PEcyhOGzyxt2tNtbJvMUTsy/WpXgXNpgDr7i2cXSB+G1vOOvvpVQfsctVPCug15Yn+JwzOFmj5OfwK+BsLbWO/8qXDtlT+CTRUTgIIOPbHb1VKx+/bbPELfef0sqe8Ra9izrdHg45F6cA/0hKk9V8KWm/3FG7FEO9Jn3ERXAh2eWUoOVAV140LzPeEsODzbg5jwZ2fiLCuS7vMFOT8w+k76OUovVoGuvZ7nWzkT34gZgMtYQ6DZWhfbXmPH+NKu+aUIDRQxEqt7XMumnvbtnDExh989m35ivu4RaFBOjcO1YuN7IopotYZXH1zvT39T/tcpm3lWq/xtWsy6TIoN6zZT0zEeosk8IO6ur2QQYMKz9FoJg5iMPGZmrdyhgtahsRqe+1XRH6pipqSFzD1U9jPQHmJCyVXTIROdB+Ql56fWvKOBKhQA95Cf0TrUnyPB5h3tK5ml2oFJHcmZA7PkkIRVz7Bwycv9xt3sGqDH/pI6m2wAyCNp0jw0IlnL0AtXtjO1siEAvT22DYjwQWR0eKbQOzuo9J3RDIsq7NYSscPMUmHP8X1h95YQWOocWEhrK4MABFKbMGJMdB5g4vAc+qs2/lCUQ92iX7K5E19lB4u8QqsSLp1XKTwgk+ZhSDlZea4J2YBQc7GN/meYx9GOq2Vpgdlpy86hbCrvMYibA5I7Ds7iFUOfncR7dHSNHCom6sghbBHdq+fCK1G7kxOtU8W+dlci7C/acKkUsKEnDFgMW0WgQ6R9GqDTtBnkCzTgkGyrJjdaokau1/AC7+1Y84k6KzhLqI1zAEmsolBrYL9GzWkxSecFb9rILN40hBHHMhnPZArDRWFcRR2ehNb85OQrL7LO3GprwMN7AmLy+susM7YalU8CQ515bKzMUCz2kNaKO5gnQ0ykCDMMvHIFcdAkMPeMfp5Ql6RiTQLlH8q4P05FHwEOggEs7aiY1FiSvUsTxV/9J3bi2d4DdtqxYG1SBZZZi+VyiLRY13+JKUY2rCa2mS+y5Rfitj5xIEDcDCjWYJOYK1OcaXBjOCATCwY0rXdGBlbMg40QAADgBNE9fW1/VoKKmNBcNo83BicRXi7BDoR5erRfA8TIIKFD/hAAAACArCNj+g07aAAAgFqdSiEEAABkAqXS8mH4BatQZ4+Us7FIIoNwcRBnfQsFO3+Py+FZOL/S900jzBUeG1++lLu8I11n7XlE8ve6xgNrEG0FASiD5Yn0nqj06WJhb8A+HRYMIibavKvwzkX2TFm/yfYs0c+d62rFHilLahmF99jx1WQkkQvHknw5enJNMrHF5IQoHDc9WZjihvRwgalwL/M4vzowNH+lTkclr01GwgwgxdHN8iWc+Th647ioWtzHEYhJTzxVZhDGRAhhuOY2TeMyUvX4syrQR+WfnSfpkJ4jfRF3GG6c0rPzOCoKozp6r3VmHpyBlEdv92TJLln7IfpD4TxT+vnw+ixmUoWxv7XisainAcLQ1BeKYvl3+ToQaDfoWebbNtwKSSMmz1lfxjFId3cOkq893Ya6IvVDFrc7N4MIh2eLIxudHpzHCVLQh56Fr1u2/SewhCRQydnsNVS3wJRzopXWFv15gGCQ0PWKCf3OKF4e1iVpuKCtW+JiL8nHWTeUrWcnCYXzifTOb9N4LigUhXKLSdSPlNfOjEIgTJ7p+cmNtjW6uogRPYbAg5fa3OSegVLNK+f+qtZWxgLaCovDc6ArsnD5N1TuQB9g+rlhqKnCgc2AKux3hM3IRFNy6NTEO1pua2wSDflr6Qlq90S5O3QG3bAjH5C4b06n5OCOULCbuLicLFFC4VyaGFtTMpcboqd9c5l0Bz6wbHLHaiimg5nFPNRh3GR4m4LEcVfFjFejwoZ1Ts7CU85oJnb5YgtE731N6qxduMRRnKvhJaHf0X+zwFhyoRzcjHsOSyYTXDVfXIr+CVfc8xLt1GgrOT90w1An9JETjGQpo5GsSJ01en21drEQLO/vtbebLpXKwevw7F6a9/yvUSWbon+iAapeQt7RySFsZ8y82mFrl4ahlvj0mphlWlIDSJP9w+QagLw7mHQW+ec12Q6JjIZeqFVexdLHU+h6DExfCBEAkdKQ6G44b3On2ooC6Tujd7Qwo3bQ2clWbY+BpXCzyjJoTOBvLixWP4GFUEAMQ00PLrABmxv2SRyzK2fhG9GMJX3ZJBNULqXJlRw4hNIYLAY2j6wNxVQald6YJuQB5TANVDgjJgGSFmHjRU2H18bLdrVc3t4p1LEdFUl0GOLxniTiZhEtv2Ey19MUhovuZQrhwGUYamFt7d8Ad0YhGQQ9qcDrr23v6A6jZkzNIHA/TyQKm+j32Hjo6odJwxM22pLfZg0iFJI9D+JxvWkcPaCgTU2cA/BxXxKTISozX767jvcke0yIOm1L9+W9WcarFESFnWOZNEriEloxvRCnIoSHF9U/y4t4FFKSQ+eebUfJTK5ScBjTnxxBwaGSTVqIuObBc9jCWrkNySTUYfptLWdjJ+Qdbd5BwlIQxWqNNgUFhQICAEj7T0LqkvFbbvxxyJcHJ2nAyPIlJCJ1h/GSBke/qXDbh7mJ51qx8ix5YjVrSwit+cjD8Y62TSZKZe/o9rbsPlARCk/uuJiFB67NxgoFvXztyCAfAnAJhyHGPUeOHpuZBasDNQHq6vbNQsnpdxd/hRPS76S9o5Oo8LohW67sCw/m7YkyyRXLdJaaxKbWZY+QBSUBqLxpDIAnAgA1CLH0moSEu9a+YAcNAABQqyqDEAAAYK8Lz83x31RFxYqtiGI9s0WrMAQTYMwmEEf3exNYiSqV7K0IZ6Oba5PDWrZ5EN7R1kpuq3KeAgQAyAMxWQkkaNkOQispQ4ysRz2cGIRK5jWITw7CcM3ZcmS0aB0b85opCe/oSjg8q4ZCJCNt4hYAv9k11Z/iY+jw7Lc7FQJGX2qp2xAAY25iTycQgyZqhex3YohbJkTJ7W1sfOpmECqTmh3XcMzTbbiOI3gYhN6CJUtSjMUoFA7lUT+kj7BuKCnvaIp8XYNpCZ6kQ2HRSo3EcOPUT3kiPvSOJr4DyTk8+0ORHPs7MHF4tqzgUDjqq3A+IzNjE4f18gLq5/v22w+AvjO6e9LjPPCETU9U/sFDzKakVBpV1fb+G7ULZ7FCFC6qDpnS/3KZy9rjx1HvT1hMSd0VdqTRPNTishRPIYKwEmrYJ06Y2pnRwwr81PaqwoRRqwijPGp1JtaTknNSEsNqxR6dBPtLQmH4vkJNZcIT7bNbiE1P1GLCGo02aKBErEf9hL4nZ5XM6B1NlXSORIpmx2IrKMjCHVsqlqXafp9xeheWkgMNk7lK1mj02t2GxTs67LEm57Zr4ixL/U5CEIk6PJs8Pnk719NaevoJOYMm6PA8qfSI2QRAjJLEAhOvobFbAxlpOrln7A89S0DERYmMvWW1HUwHP1AW8Q6bzxkqVtggw9DhuSLe0clNbU3iXCmHZ5NoRL5W2zu6gg9Izw2Xo+Q4AkAc5/TJQh3z+k/gv3OEjFc7jy7BqHAVf5ysmUsvVuml5VFxjiMAgwNl0w+PcaY53Mf/kjPoYExx8280GdoOhxVrMfkxBFaPZRM4rHqGoZbUTWL+bFLhROucXCKQSfOQR9KkeUS+VjsgkS/Ue4jJ+UKrhFFvPK3ySaPePeZjsD1GNjCYLHrQ3WWnHFDhvT0JHto2dNJww3NjMNWc5Qi7/8y68MNiEIAgE0GWkgMNJs1zHykUgUOBsJ+ro70tuG52+mOHaQOLFSUWmLhSy218TOIsr5VJyfIEMzE81dPRhERayeG5lT8UagPTzKSBUptI2pyPGJDLC4jayvD68o4Tr7WZ4z1JczfhIcoyThfeyE7uI/2vUFwWaaGi3Ls4QshZVNZzw60wnjRXWeE96fGONr8Vg54dNTD/nk3Q3RLxLD0oDgcPBUznqdi+dqNWQUEOzJyJ6R19otfDnq3W8KmxH7hKTKhHSG4nNml4VHISG5DCSVCyXk/NQ6/h0QMaG5Mt8ih4R9dZex6xMg+YwbGBmosQLfZixQ424x1tAtTbxV5lsZ5ziGBfS7ByeJLxTKa1vGnvHPikkolWWITWc1zL4rCHFPAf14p/KsInAFqKryiKYQn7hoeqrOUMlMALDwwPoISdXRCDBpM1D8nZBXHTRtRDhAAAQH7g5IlR92ZcshCZiCJjpLlJYxUlVQEQFU7CO9oSB3THy0loMW0VIkAqa9twllZnouI6XvaRgRXjxDVOAgNAfpDQiWLzuzNTRh7vfiC6Fzfi8d45KEb6Isd9cSmu5xIEAAAAIC0kdOeg7k4k7KABAABqFBAAAAAACAAAAAAAAQAAAAAgAAAAAAAEAAAAAKgi5CMN9I59B/CoAAAAMAMAAAAAIAAAAAAABAAAAACAAAAAAAAQAAAAAAACAAAAAEAAAAAAAAgAAAAABAAAAACAAAAAAAAQAAAAAKBKgSshaw6XbBoxL8TcnSnta8Qzhux8fJb20Mvh1lXjTQIzAAAAAAACAAAAAEAAAAAAAAgAAAAAAAEAAAAAIAAAAAAABAAAAACAAAAAAAAQAAAAAAACAAAAAEAAAAAAIAAAAAAABAAAAACAAAAAAAAQAAAAAAACAAAAAEAAAAAAAAgAAAAAAAEAAAAAIAAAAAAABAAAAACAAAAAAACZwP8RYAC2/xDsCX1VfgAAAABJRU5ErkJggg=="></image></g></symbol><symbol id="wds-company-store-appstore" viewbox="0 0 119 35"><g fill="none" fill-rule="evenodd"><path d="M114.766 35H4.17C1.87 35 0 33.138 0 30.859V4.135C0 1.855 1.87 0 4.169 0h110.597C117.063 0 119 1.855 119 4.135V30.86c0 2.279-1.937 4.141-4.234 4.141" fill="#A9AAA9"></path><path d="M118.147 30.86c0 1.851-1.511 3.35-3.38 3.35H4.17c-1.87 0-3.385-1.498-3.385-3.35V4.134C.785 2.284 2.3.78 4.169.78h110.597c1.87 0 3.38 1.505 3.38 3.355V30.86" fill="#0A0B09"></path><path d="M26.557 17.311c-.025-2.82 2.327-4.192 2.434-4.257-1.332-1.928-3.396-2.19-4.122-2.211-1.734-.181-3.416 1.03-4.299 1.03-.9 0-2.262-1.012-3.727-.983-1.885.03-3.65 1.113-4.619 2.797-1.997 3.432-.507 8.477 1.406 11.251.958 1.36 2.076 2.877 3.54 2.823 1.432-.06 1.967-.907 3.696-.907 1.713 0 2.216.907 3.709.873 1.537-.025 2.505-1.365 3.429-2.736 1.106-1.558 1.55-3.092 1.568-3.171-.036-.012-2.986-1.129-3.015-4.509m-2.82-8.293c.77-.957 1.296-2.258 1.15-3.578-1.115.049-2.51.765-3.312 1.7-.71.825-1.345 2.176-1.181 3.447 1.253.092 2.539-.628 3.343-1.57M43.858 22.71l-.992-3.04c-.104-.31-.301-1.042-.592-2.194h-.034a84.012 84.012 0 0 1-.557 2.195l-.974 3.04h3.15zm3.43 4.856h-2.003l-1.096-3.42h-3.811l-1.045 3.42h-1.948l3.776-11.644h2.332l3.794 11.644zm7.796-4.233c0-.817-.185-1.491-.557-2.021-.407-.553-.951-.83-1.636-.83a1.96 1.96 0 0 0-1.262.459 2.115 2.115 0 0 0-.74 1.2 2.42 2.42 0 0 0-.087.57v1.4c0 .61.19 1.126.566 1.546.378.42.868.63 1.47.63.708 0 1.26-.27 1.654-.811.394-.542.592-1.256.592-2.143zm1.914-.068c0 1.427-.388 2.556-1.166 3.385-.696.738-1.56 1.106-2.593 1.106-1.113 0-1.914-.397-2.401-1.193h-.036v4.423h-1.879v-9.052c0-.898-.024-1.82-.07-2.765h1.653l.105 1.331h.035c.626-1.002 1.578-1.503 2.854-1.503.998 0 1.83.391 2.498 1.174.667.784 1 1.815 1 3.094zm7.815.068c0-.817-.186-1.491-.557-2.021-.407-.553-.952-.83-1.636-.83-.465 0-.885.154-1.263.459a2.123 2.123 0 0 0-.738 1.2c-.058.231-.088.42-.088.57v1.4c0 .61.189 1.126.564 1.546.378.42.869.63 1.473.63.707 0 1.258-.27 1.652-.811.395-.542.593-1.256.593-2.143zm1.914-.068c0 1.427-.388 2.556-1.167 3.385-.695.738-1.56 1.106-2.592 1.106-1.114 0-1.915-.397-2.401-1.193h-.036v4.423h-1.879v-9.052c0-.898-.024-1.82-.07-2.765h1.654l.104 1.331h.035c.626-1.002 1.576-1.503 2.854-1.503.997 0 1.83.391 2.498 1.174.666.784 1 1.815 1 3.094zm10.878 1.036c0 .99-.347 1.796-1.042 2.418-.764.68-1.828 1.02-3.196 1.02-1.26 0-2.274-.242-3.04-.726l.436-1.555a5.18 5.18 0 0 0 2.716.743c.708 0 1.26-.158 1.655-.476.395-.317.59-.741.59-1.272 0-.473-.16-.87-.487-1.194-.323-.323-.864-.623-1.617-.9-2.054-.76-3.081-1.874-3.081-3.34 0-.956.36-1.741 1.08-2.353.717-.611 1.674-.917 2.871-.917 1.068 0 1.955.184 2.662.552l-.47 1.521c-.661-.357-1.409-.535-2.245-.535-.661 0-1.178.16-1.548.483a1.38 1.38 0 0 0-.47 1.055c0 .46.179.84.54 1.139.312.277.88.577 1.705.9 1.01.403 1.75.874 2.228 1.415.476.542.713 1.216.713 2.022m6.213-3.731h-2.071v4.076c0 1.037.365 1.555 1.096 1.555.336 0 .616-.029.836-.086l.051 1.417c-.37.137-.857.206-1.461.206-.743 0-1.323-.224-1.741-.672-.416-.45-.627-1.204-.627-2.264V20.57h-1.234v-1.4H79.9v-1.538l1.846-.553v2.09h2.071v1.4m7.398 2.79c0-.774-.168-1.438-.505-1.992-.394-.67-.958-1.005-1.687-1.005-.756 0-1.33.334-1.724 1.005-.337.554-.504 1.229-.504 2.027 0 .774.167 1.439.504 1.992.407.67.975 1.005 1.707 1.005.717 0 1.28-.34 1.687-1.022.347-.565.522-1.236.522-2.01zm1.95-.06c0 1.29-.371 2.35-1.114 3.178-.778.853-1.811 1.279-3.099 1.279-1.241 0-2.23-.409-2.966-1.227-.737-.817-1.106-1.849-1.106-3.092 0-1.301.38-2.367 1.14-3.196.76-.83 1.783-1.244 3.071-1.244 1.242 0 2.24.409 2.995 1.227.719.794 1.079 1.819 1.079 3.075zm6.108-2.489a3.281 3.281 0 0 0-.592-.05c-.661 0-1.172.247-1.532.742-.314.438-.47.99-.47 1.658v4.406h-1.878l.016-5.752c0-.969-.023-1.85-.07-2.645h1.638l.068 1.607h.052c.198-.552.512-.997.94-1.33.418-.3.871-.449 1.358-.449.174 0 .331.012.47.034v1.78m6.613 1.676c.013-.553-.11-1.03-.365-1.434-.325-.518-.825-.777-1.497-.777-.615 0-1.115.252-1.496.76-.314.403-.5.887-.556 1.45h3.914zm1.792.484c0 .334-.022.616-.069.846h-5.637c.022.83.294 1.463.817 1.901.475.391 1.09.587 1.844.587.834 0 1.596-.133 2.281-.398l.294 1.296c-.8.346-1.745.519-2.835.519-1.312 0-2.342-.384-3.09-1.15-.747-.766-1.123-1.794-1.123-3.084 0-1.267.347-2.32 1.046-3.16.73-.9 1.716-1.348 2.957-1.348 1.219 0 2.142.448 2.769 1.347.497.714.746 1.596.746 2.643zM42.263 8.783c0-.667-.178-1.18-.535-1.536-.357-.356-.877-.535-1.56-.535-.292 0-.54.02-.745.06v4.277c.114.018.322.026.624.026.707 0 1.253-.195 1.638-.585.385-.39.578-.96.578-1.707zm.974-.025c0 1.03-.31 1.805-.932 2.326-.577.48-1.394.72-2.454.72-.525 0-.975-.022-1.351-.067V6.11c.49-.079 1.02-.118 1.59-.118 1.01 0 1.77.218 2.284.654.574.492.863 1.196.863 2.113zm4.206.929c0-.38-.083-.706-.248-.978-.194-.33-.47-.495-.83-.495-.37 0-.652.165-.846.495-.165.272-.248.604-.248.995 0 .38.083.707.248.98.2.328.478.492.838.492.354 0 .63-.167.83-.501.17-.278.256-.607.256-.988zm.958-.03c0 .635-.182 1.155-.547 1.562-.383.42-.89.629-1.522.629-.61 0-1.096-.2-1.458-.603-.362-.402-.543-.909-.543-1.52 0-.639.186-1.162.56-1.57.373-.408.876-.61 1.508-.61.611 0 1.1.2 1.472.602.352.39.53.894.53 1.51zm6.925-2.027l-1.3 4.124h-.845l-.54-1.791a13.32 13.32 0 0 1-.334-1.333h-.016c-.08.453-.191.898-.334 1.333l-.573 1.79h-.855L49.307 7.63h.949l.47 1.96c.113.465.208.906.283 1.325h.016c.068-.345.182-.784.342-1.316l.59-1.969h.752l.565 1.927c.137.47.248.922.333 1.358h.026c.062-.425.157-.877.283-1.358l.504-1.927h.906m4.789 4.124h-.924V9.39c0-.728-.278-1.092-.837-1.092a.837.837 0 0 0-.667.301c-.171.2-.257.436-.257.707v2.447h-.924V8.809c0-.363-.011-.755-.033-1.18h.812l.043.645h.026c.107-.2.268-.367.478-.498.25-.155.53-.232.838-.232.387 0 .71.125.967.374.319.305.478.76.478 1.366v2.47m1.625-6.017h.923v6.017h-.923zm5.402 3.95c0-.38-.082-.706-.247-.978-.193-.33-.471-.495-.829-.495-.372 0-.654.165-.847.495-.165.272-.248.604-.248.995 0 .38.083.707.248.98.2.328.479.492.838.492.354 0 .629-.167.829-.501.172-.278.256-.607.256-.988zm.96-.03c0 .635-.183 1.155-.548 1.562-.382.42-.89.629-1.522.629-.611 0-1.097-.2-1.458-.603-.362-.402-.542-.909-.542-1.52 0-.639.186-1.162.559-1.57.373-.408.877-.61 1.508-.61.612 0 1.1.2 1.472.602.353.39.53.894.53 1.51zm3.511.679V9.7c-1.019-.017-1.528.26-1.528.832 0 .215.058.376.177.483.119.108.27.161.451.161a.927.927 0 0 0 .564-.19.777.777 0 0 0 .336-.65zm.96 1.418h-.83l-.07-.475h-.025c-.284.379-.689.569-1.214.569-.392 0-.709-.125-.949-.374a1.168 1.168 0 0 1-.325-.84c0-.504.212-.888.637-1.155.425-.265 1.023-.396 1.793-.39v-.077c0-.543-.288-.814-.863-.814-.41 0-.772.101-1.083.305l-.188-.603c.386-.237.862-.356 1.426-.356 1.086 0 1.63.569 1.63 1.707v1.519c0 .412.02.74.06.984zm4.291-1.74v-.687a1.043 1.043 0 0 0-.36-.844.908.908 0 0 0-.617-.226.952.952 0 0 0-.813.407c-.197.272-.296.62-.296 1.044 0 .408.094.739.284.993.2.271.47.408.807.408a.895.895 0 0 0 .73-.34c.178-.209.265-.46.265-.755zm.958 1.74h-.82l-.042-.662h-.027c-.262.503-.707.755-1.334.755-.501 0-.917-.195-1.248-.585-.33-.391-.496-.897-.496-1.52 0-.667.179-1.208.539-1.62a1.662 1.662 0 0 1 1.283-.578c.557 0 .948.187 1.17.56h.017V5.737h.925v4.906c0 .401.01.771.033 1.11zm6.943-2.067c0-.38-.083-.706-.248-.978-.194-.33-.47-.495-.83-.495-.37 0-.652.165-.847.495-.165.272-.248.604-.248.995 0 .38.083.707.248.98.2.328.479.492.839.492.353 0 .63-.167.83-.501.17-.278.256-.607.256-.988zm.957-.03c0 .635-.182 1.155-.547 1.562-.383.42-.889.629-1.522.629-.61 0-1.095-.2-1.458-.603-.362-.402-.542-.909-.542-1.52 0-.639.186-1.162.56-1.57.372-.408.875-.61 1.51-.61.608 0 1.1.2 1.469.602.353.39.53.894.53 1.51zm4.968 2.097h-.923V9.39c0-.728-.279-1.092-.839-1.092a.833.833 0 0 0-.666.301c-.17.2-.257.436-.257.707v2.447h-.924V8.809c0-.363-.01-.755-.033-1.18h.811l.043.645h.026c.108-.2.269-.367.478-.498.252-.155.531-.232.839-.232.388 0 .71.125.966.374.32.305.478.76.478 1.366v2.47m6.218-3.438h-1.019v2.004c0 .509.181.764.54.764.165 0 .302-.014.41-.043l.025.696c-.182.068-.422.102-.718.102-.365 0-.649-.11-.853-.331-.207-.221-.309-.591-.309-1.112v-2.08h-.608v-.687h.608v-.756l.905-.271v1.027h1.019v.687m4.89 3.438h-.924V9.409c0-.74-.28-1.11-.837-1.11-.429 0-.721.215-.882.644-.027.09-.042.2-.042.33v2.48h-.923V5.738h.923v2.485h.017c.29-.452.708-.678 1.248-.678.383 0 .699.125.95.374.314.31.47.772.47 1.383v2.453m4.163-2.497a1.23 1.23 0 0 0-.179-.704c-.16-.255-.404-.382-.735-.382a.88.88 0 0 0-.735.374 1.38 1.38 0 0 0-.274.712h1.923zm.882.238c0 .165-.013.303-.035.416h-2.77c.012.408.144.718.4.934.235.192.539.288.909.288.41 0 .783-.064 1.12-.195l.145.636c-.394.17-.857.256-1.395.256-.643 0-1.15-.188-1.516-.565-.368-.377-.55-.882-.55-1.515 0-.622.17-1.14.512-1.553.358-.442.842-.663 1.453-.663.598 0 1.052.221 1.358.663.246.35.369.784.369 1.298z" fill="#FFF"></path></g></symbol><symbol id="wds-company-store-googleplay" viewbox="0 0 119 35"><g fill="none" fill-rule="evenodd"><path fill="#000" d="M114.593 35H4.407C1.94 35 0 33.075 0 30.625V4.375C0 1.925 1.94 0 4.407 0h110.186C117.06 0 119 1.925 119 4.375v26.25c0 2.362-1.94 4.375-4.407 4.375z"></path><path fill="#A6A6A6" d="M114.593.7c2.027 0 3.702 1.662 3.702 3.675v26.25c0 2.013-1.675 3.675-3.702 3.675H4.407C2.38 34.3.705 32.638.705 30.625V4.375C.705 2.362 2.38.7 4.407.7h110.186zm0-.7H4.407C1.94 0 0 1.925 0 4.375v26.25C0 33.075 1.94 35 4.407 35h110.186c2.468 0 4.407-1.925 4.407-4.375V4.375C119 2.013 117.06 0 114.593 0z"></path><path fill="#FFF" stroke="#FFF" stroke-width=".2" d="M41.475 8.925c0 .7-.175 1.313-.613 1.75-.525.525-1.137.787-1.925.787-.787 0-1.4-.262-1.924-.787-.526-.525-.788-1.138-.788-1.925 0-.787.262-1.4.788-1.925.525-.525 1.137-.788 1.925-.788.35 0 .7.088 1.05.263.35.175.612.35.787.612l-.438.438c-.35-.438-.787-.612-1.4-.612-.524 0-1.05.174-1.4.612-.437.35-.612.875-.612 1.488 0 .612.175 1.137.613 1.487.437.35.875.613 1.4.613.612 0 1.05-.176 1.487-.613.263-.262.438-.612.438-1.05h-1.925v-.613h2.537v.263zM45.5 6.737h-2.362V8.4h2.187v.612h-2.187v1.663H45.5v.7h-3.062v-5.25H45.5zm2.888 4.638h-.7V6.737H46.2v-.612h3.675v.612h-1.487zm4.025 0v-5.25h.7v5.25zm3.674 0h-.7V6.737H53.9v-.612h3.587v.612H56v4.638zm8.313-.7c-.525.525-1.138.787-1.925.787-.788 0-1.4-.262-1.925-.787-.525-.525-.787-1.138-.787-1.925 0-.787.262-1.4.787-1.925.525-.525 1.138-.788 1.925-.788.788 0 1.4.263 1.925.788.525.525.787 1.138.787 1.925 0 .787-.262 1.4-.787 1.925zm-3.325-.438c.35.35.875.613 1.4.613.525 0 1.05-.175 1.4-.612.35-.35.612-.875.612-1.488s-.174-1.138-.612-1.487c-.35-.35-.875-.613-1.4-.613-.525 0-1.05.175-1.4.612-.35.35-.613.875-.613 1.488s.175 1.137.613 1.488zm5.075 1.138v-5.25h.788l2.537 4.113V6.125h.7v5.25h-.7l-2.712-4.287v4.287z"></path><path fill="#FFF" d="M59.587 19.075c-2.1 0-3.762 1.575-3.762 3.762 0 2.1 1.662 3.763 3.762 3.763s3.763-1.575 3.763-3.763c0-2.274-1.663-3.762-3.763-3.762zm0 5.95c-1.137 0-2.1-.962-2.1-2.275s.963-2.275 2.1-2.275c1.138 0 2.1.875 2.1 2.275 0 1.313-.962 2.275-2.1 2.275zm-8.137-5.95c-2.1 0-3.763 1.575-3.763 3.762 0 2.1 1.663 3.763 3.763 3.763 2.1 0 3.762-1.575 3.762-3.763 0-2.274-1.662-3.762-3.762-3.762zm0 5.95c-1.138 0-2.1-.962-2.1-2.275s.962-2.275 2.1-2.275c1.137 0 2.1.875 2.1 2.275 0 1.313-.962 2.275-2.1 2.275zm-9.713-4.813v1.576H45.5c-.087.875-.438 1.575-.875 2.012-.525.525-1.4 1.137-2.888 1.137-2.362 0-4.112-1.837-4.112-4.2 0-2.362 1.837-4.2 4.112-4.2 1.225 0 2.188.526 2.888 1.138l1.138-1.137c-.963-.876-2.188-1.575-3.938-1.575-3.15 0-5.863 2.624-5.863 5.775 0 3.15 2.713 5.774 5.863 5.774 1.75 0 2.975-.524 4.025-1.662 1.05-1.05 1.4-2.538 1.4-3.675 0-.35 0-.7-.087-.963h-5.425zm39.726 1.226c-.35-.875-1.225-2.363-3.15-2.363-1.925 0-3.5 1.488-3.5 3.762 0 2.1 1.575 3.763 3.674 3.763 1.663 0 2.713-1.05 3.063-1.663l-1.225-.875c-.438.613-.963 1.05-1.838 1.05-.874 0-1.4-.35-1.837-1.137l4.987-2.1-.174-.438zm-5.075 1.225c0-1.4 1.137-2.188 1.924-2.188.613 0 1.225.35 1.4.787l-3.325 1.4zm-4.113 3.587h1.662V15.312h-1.662V26.25zm-2.625-6.387c-.438-.438-1.138-.875-2.013-.875-1.837 0-3.587 1.662-3.587 3.762s1.663 3.675 3.588 3.675c.874 0 1.575-.438 1.924-.875h.088v.525c0 1.4-.788 2.188-2.013 2.188-.962 0-1.662-.7-1.837-1.313l-1.4.613c.438.962 1.487 2.187 3.325 2.187 1.925 0 3.5-1.137 3.5-3.85v-6.65H69.65v.613zm-1.925 5.162c-1.137 0-2.1-.962-2.1-2.275s.963-2.275 2.1-2.275c1.138 0 2.013.962 2.013 2.275s-.876 2.275-2.013 2.275zm21.35-9.712h-3.938V26.25H86.8v-4.113h2.275c1.837 0 3.587-1.312 3.587-3.412 0-2.1-1.75-3.413-3.587-3.413zm.087 5.25H86.8V16.8h2.362c1.225 0 1.925 1.05 1.925 1.837-.087.963-.787 1.925-1.925 1.925zm10.063-1.575c-1.225 0-2.45.524-2.887 1.662l1.487.613c.35-.613.875-.788 1.487-.788.876 0 1.663.525 1.75 1.4v.087c-.262-.174-.962-.437-1.662-.437-1.575 0-3.15.875-3.15 2.45 0 1.487 1.313 2.45 2.713 2.45 1.137 0 1.662-.525 2.1-1.05h.087v.875h1.575v-4.2c-.175-1.925-1.662-3.063-3.5-3.063zm-.175 6.037c-.525 0-1.313-.262-1.313-.962 0-.875.963-1.138 1.75-1.138.7 0 1.05.175 1.488.35-.175 1.05-1.05 1.75-1.925 1.75zm9.188-5.775l-1.838 4.725h-.088l-1.924-4.725h-1.75l2.887 6.65-1.663 3.675h1.663l4.462-10.325h-1.75zm-14.7 7H95.2V15.312h-1.663V26.25z"></path><path fill="url(#store-googleplay-gradient-1)" d="M9.1 6.563c-.262.262-.438.7-.438 1.224v19.338c0 .525.175.962.438 1.225l.088.087 10.85-10.85v-.174L9.1 6.563z"></path><path fill="url(#store-googleplay-gradient-2)" d="M23.625 21.262l-3.587-3.587v-.262l3.587-3.588.087.088L28 16.363c1.225.7 1.225 1.837 0 2.537l-4.375 2.363z"></path><path fill="url(#store-googleplay-gradient-3)" d="M23.712 21.175L20.038 17.5 9.1 28.438c.438.437 1.05.437 1.838.087l12.774-7.35"></path><path fill="url(#store-googleplay-gradient-4)" d="M23.712 13.825L10.938 6.563c-.788-.438-1.4-.35-1.838.087L20.038 17.5l3.674-3.675z"></path><path fill="#000" d="M23.625 21.087l-12.688 7.175c-.7.438-1.312.35-1.75 0l-.087.088.088.087c.437.35 1.05.438 1.75 0l12.687-7.35z" opacity=".2"></path><path fill="#000" d="M9.15 28.262c-.3-.262-.4-.7-.4-1.224v.087c0 .525.2.962.5 1.225v-.088h-.1zM28 18.637l-4.375 2.45.087.088L28 18.725c.613-.35.875-.788.875-1.225 0 .438-.35.788-.875 1.137z" opacity=".12"></path><path fill="#FFF" d="M10.938 6.65L28 16.363c.525.35.875.7.875 1.137 0-.438-.262-.875-.875-1.225L10.937 6.563c-1.224-.7-2.187-.088-2.187 1.312v.088c0-1.4.963-2.013 2.188-1.313z" opacity=".25"></path></g></symbol><symbol id="wds-company-store-logo-ddb" viewbox="0 0 78 78"><g transform="translate(-.222 -.111)" fill="none" fill-rule="evenodd"><mask id="mask-2" fill="#fff"><use xlink:href="#path-1"></use></mask><image mask="url(#mask-2)" x="-3" y="-2" width="84.444" height="85" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJgAAACZCAYAAADTnvOEAAAaj0lEQVR4nO2deZAdxX3Hv/321i66QUKAgiQEki0qBFdxlGNsyWXHAhyBBcGGcpnggGUcQI5zFBVOu0zZYDBgrsIHxAWBglASAoKQOEQBiYrDXpCJBQZLSAJ0sNq3qz20x5vOH29mXh+/7jnezLxj37fq7Zvp7unpmf7M7/frnnmzDIp2Nk/9AmvKrQBwFoCj1fyGGiLUzTi6R3PO9fMO5reLGcxb2DZ16tSW4dy1AFZn3LiG6kkObh3rdK6fl8/nARcwF64XAJxQwaY1VD/qHutwls7L5/M5AHAt1wmVbVNDdaQTWgZz1wIA29Y+9egWnttW6RY1VH/iBWdprtUpktZQQ4mrKXdWjjdcY0MpKQesYLvapvNKN6Sh+lWu0g1oqL7VXOkGVJOSMuUsuMiE0YQFLApMtrIUTFT5iQrdhALMBAqZzsJByOHCQxRmSjkqvd5V14Cpfc6pZUbnB9WlwcP0PO7+CQKqnoGrO8ACoWLB5eLsh8pj7h/fyhEbMtS3dasbwEzAcAIoCg4aGG7JE2HQsVDB8SEzAMfk1boBraYBM0GjQmUsR6BDuc7g/fMAUJifJuYzt60ejEyoo15Aq1nAVGi4EkvRFo2TIFJ1RpYAtRqfMW53gipsqCPQag4wE1hma1WCinKXprqTlLdf5raGSTtiujv1rJo7QKhl0GoGMBUgERYrVIA25RAnwLeNIk1lxTIiJDJA3LVgRI3eMdYwaFUPWFiLJYKlukuqHtM+tDRDT3JiJQg6LV9qp2fZzKCprrMWIKtqwCirFQYsCiZrmqWngqwb8/8Q4IYAT62Mc24enaojCLpUVakqAQsLlucI7VaNSAuYXI0Si1ldpzqI4DIjpCWS3KKcK051eAnV7jarDjAqduJqusFiGb8tQMWJx2JLJcC2M//YAlxnlbvNqgJMsk7umXKUfA4eCiyTpTIBlRRYkayJEsRby3FDzYQ1qybIqgIwk0s0uUMjUCiBFTYO09pRbu8QFYudbgv2raD5FXBwasypzHVUC2QVB4yyWhRcpjx1WzWd+vbLJTnR6olpfQ3Gw9XNvAsjyHXarFmVDQAqCpgKSFirRblCk8WyQaW7S66shxezrElPWnC5fSQAxGhRKitYM23PAqTV4DIrBlgYuOyBvtldat/G6QuupceVXHdxrcRJyaX5t4OgWzYPBh8Kw7SEL2lag7ZmlYasIoCZ4Cqlc7vVIoJ8Cj5qf0FQJQGbzgUncsmCfjJXEkxutmSxCIyqALLMAbNbLrNLpNyhyRXqAFLPTchloNRdlqzA6LB5kHgQkTAY5r7knRS3lPIrDFmmgNkslwqXLdYyWi4NPh0synWqeeVKdIMApNEhBZvnQr3trIMCki4xrzjKzInFKghZZoAFwaWOEqnyIPKg5MOrj9i3V5ZKp9bjShtFiu0jdlK84S1YnhCxlzGfAYxzOOpURoUgywQwo1tsaUHXuWejac5szc3524WY01LzyDQLWKa0csQAjO7ZA4yMoHBgAIW+PMb37kOhrx+Fvj7wsXGtBSUHp7TZarFMMVsRWlP5rJQ6YFbLNTaKwv5ezPzFLWCTOtJuSlXIGRrCeG8vRt59D4Ovv46h3/0eI++8i5H3/wwUCoLtLY0NeaBbpNMZVyyjUj4L0FJ9dUAYt8gBdCz7AuY88uCEgUyVMzSEkXfexeCrr6H/2ecw8Pwm8JERiPbMi838ZcjLap6czsh0sZ60lDpgYWOuzjOX4/AH7wdraUmrOTWjQn8/Bl96BfsfeRQHnnoazsERGSpOAAY7ZEyFjIA1DaUGmFepA2iTpaL1Ej+Tv3U+Zt92C1hraxpNqkmN7tyFfbffgb51T2D8w48ByBbIX0c8yMQ60lAqgIV1jdLHTZvyzfNx+J23gTU1Jd2smhYfHUXPr36D3T+8Ac7AQM1AlhpgkeBCafqAM4ZpF12I2T+/Cayp8fIfVWO7d2PfrXeg5557gfFxK2TmdBqymgAsKlwgywIz/3k1Zl93dXESqSFN+cfW4KMrfoBCPq8BQoFTKSuWqIkwT1xyad3uQovad/Ot2PuzW5NsXl1p6sqzseDFjWidP8/qFeg0TpYDkp8PTNwHUQ2WXKCQrgf/bp6bPvTGG0k3r67UtmABFmx8Gu1Llmh3M4D4kCWpxAAjryAEB/U2d9lQsJpnHYb5T61B67yjzefU+OFSPoTySSkRwKQGMTmHfGbL4Ojlq8j8BERDsppmzMDRax9Fy5w55LN1ZGCleBQgHSuWrAUzXEEAAZn6kbZtwBVVbQsWYM4tN/mDotjxGPS+K0dlA0b6fURzjVy1ekj2ICeKJp+5HFPOWWl8INP28SX0RRLnPzEXaQwyobtGasRCWr3GDEVkzbnxBrBJk+gXvRhdZXoBf1mAmQAR7zWqZal4jAw6G3DFUvOhMzFz1SUAbG7RHPCrKhe0sh/XoWAgRzCWgy2Wk+HK0j2O7/sEzvBQ7O1zkzrRNPmQqrmHOv3Cb+KTe+4FHyodE4duwPw0VlzRrB0vf+I1NmC22Isaodjroi1XVpDtuGw1+p98CoAyox22Ae4F0TxjBlrmHoX2xYtwyNKl6Drts2g54ojkGxyg1vnz0PGZEzH40ssSKP7hhEhLyoGUZcFs1ibcCIYO5rMO7sXbJsWTzORMmzj8jil80oNCTw+Gf9+N/f/5MJq6utC1bCmmn/91TDn9K0Auu3urk89YXgRMaGYwPMQDiq7iApdckI9S7GUChAaKdo1ZjiIZgBwv3qFjjIGxEnA5HvBxyzGG4rZgyHH3RxcDA+hf9wS2ff0C7Lj0cjhDwxkdETD5K1+CPwVBjSoDpi0AJGLGYgFmg8BmqXxZrJep3jQl3vQVwclBtm6mT07ZtpjOwDjzbyT3PvAgtl/49+Dj6rP46ah13jywtnYAep94UgdcUPLUWDqOYlswDihzJvrIMWQtFQnsRUmgKGleOvWxQueBxphrHYED6zfiwPoN2RxTUxPaP72YtEY+ONRdFtDGIK4iA6ZeAaGsmPgxDJOD6kxT4mMtIjy+RTJ8VGunQpdz6yi6XAZW4Nh3592ZHVfLEXPgDaFsFkxaJ+bFTOXDKFaQL/p1L4UEw2rRhJIVvsHtwQBAehpUzKfEtQW3vHA80miUAcObXwUfGwdrSf8Xg01TJstBvTIdwQDpF0tBxxknJCt7olU0t6Y8k/UCdKiS8PtRJcZfoqv0R5bKusmNivGYWo+XzsfGMLZzZybHxYWlMOfSZOnKCfYjXUZB5tUGHFWTGAeQ5jojUeCAWFa38aS2lQHgXD4PHEXIOAecgYHyGhxBJetD/BBXkWzpSuXLGUxGttO6e7TDoFokmyuU8pKa6QspDTAesQlKEM2EFc9lOsj8sHRRk1yuuFKMSlfzglTWTH7xo/cEGSCKZxwlUKljzfo+pGTBuAhahIbY3lnuZuUyHik7Y2NqEwCUmuhfCAR0XmxWblfEDvLV9bCjPxIoYtusXWTO5yO6Wyj2hTsD7r4QjrxI3B7N6voZee99EhQxzWS13JL+cdksn02hAbMF5ZqIORfKVZL7UbbNRJwGKywIkkv0gy7D5Z9rQsv8+XFaGUmF/fsx9OZbSqrcUkmsZIQBs4uMenHEDvKL63b3aI2nLFMTWU9XqHBFgUzsMm+Ze3W6kIllWhYsQK6rM5F229T33PPghYLWfqq9URVlu+gu0lBzGPdoKlHNo0hbHMKBgJ9typABwJTzzyunqeHkONhz1z3kORQ9nc1FilMcfixaOpzQijeKhAUAwsWZvqm6KyURMKA04Srmi/KvYi6sk2e+1Cutixdh2mXfTaS9NvW98CIGXn9DmXbwVoRAMOiEx4y7RJX/uE5AG2z/lUPbThllZQWcBBc3WDJiG2ETf+5L7TvP+TbNnInZD94P1tGeVLNJ8YKDnVddHW9bYTmpGCzUTD5teczdT0NHR5DhXGu68oHiursUy4TK40paSws6V5yBI994Ba2Ljk2l/Z6442DnNddg6A9v63nKt7oMIBI9Yfss2igyxAgvCVgqAV2Ue5BqnhrT5FpawGbPQsfyL6PzWxeg7cQTEmypWfkNG7D7jru0dDUol60rLXnAEl+hXn7iu0Jh5OeAK+t6GXndvR/W2oIjb74Jbccs0PahHknzjBmYtHhxGYcXTmN/eh/Ox7sTqSvX1YXcrEORO/RQsNbsXqaXf/ZZvHfRxf7LUADdspbWGZEm30cVt8uBGeoJVmTAfJAEwCi4vP+SVirD/bq6TvtrHLNuDVhzxf9VUu2Lc/Ru2Ij3V12K8Z4e2k1DhSM7wFJ/SFx0d95y/0sv44PvXZ72rieEdt93P7Z+4wKM9fRE3zik75MsUER/mfgvu8Oq56GH8cn9vy139xNW43192Hruefjz6n+K8Rh2+PnIcpWKBQszguScY8e//hsGu7vTaELdaqynB3t/cx+6P3MS9j+jP36dBCS6xeKx6y0rBnMMAb2jpXGtjPdpP+5YHLduDVrnzInR/ImjkW3bsP/Rx7DvgQcwvP0DKc4FlDsRahwFKn6i4zDqYUnxrYhqnBakSIDJQCUDGAfQdcopWPzkWrC2thBNnlga/N/N+PjGmzHw2msY7+srnlvhPHsKAgwQf/GUHWBV8Zbdgc2bsesnP610M6pSnaeegrm3/xyH/8sP0LHk05VuTmRVhQUDALS14pj7fo3pXz0z2SOsIzkHD2Jg82bs+fV9yG96EWN9fX5etVqwqgGMM6Bp2jQc//KLaDvqqBBNn9ga2rIFO67/EXo3Pus/5FiNgFWFi/Q03tuLP37tHIzHmdOZYJp0/PFY9F+PYMnG9Zi0aFFg+YjTV4kpEmBZNHL4nXex/cqrAMcJLtwQDjnpJCzZuB5HfH81cl1dACoHE6WyLFi5B2Laft/DD+Oju+8ps/aJo+YpUzD3+mtx7AO/RevMmWXXJ/ULL6aEdYmqUnGRTPmWmsa1FFIf/PvVyD/7XKLtqndNXbYUn3rmaXQsOi6gpDfbracmbf3KBixpK+atc8fB7satpMhqX3gMjlv7GDoWLkysznL6OPXHGRhKF4q4rIlDP5JCIaVWyer/8Y0Y697ir8c5oeJxsZkz0Dz3SLQs+RTav7QMrD3dp1hVtR5xBBY+9AD++MUvw/GmMpK6yRixnsiA+RZGSeNeIlPSlG2o7bV6Mtbom1sw/MR/S2BFgYwTy96j4qyrE22f+ywOWfUPaF/2+cweUWo/7ljMveUmbP/2JX4adUzqVIaaZyofVqFdJAP03lfuYZdjSqth5KOCEgS7WkaFiwMoDAxi8OkN2L3i7/DhSZ/D8KaXEmptsGacsxJTTl9OhiFB/aXH0fEUOwYz7TgpULIGzvQ/ktRJYe0OhFDOqwdEGQ6Oka3v4MPTV2DfldeAZ+H+czkc+eMfIdfWFg6YCO4jbP+EAoxunHnoqg9zlVRhJCnVEXKEmbTEJtpeTkxtJ92hIODy7nqI9fbefif2fPdySD+lTkntC+aj8+STQ5UN6s9MpinC7kSFR711EcYCZgUadduKE3nkLS7oYNngKmZw5B98CEObXkzpiAQxhmnnrhQTSo0zbeItcCItomK5SBUQiXCi4VGgrJS48u1bM8Ey+WXFdEZvb4JLvFf7ya13JH8ghKYs/xtpXe07ezwme56ofRQdMAkgcio1XGOFFOoAs4QtTJxFwWbbzgSXCOXQq6+ndUiSWmbNQuvhh5MexaQwA4EwijSKJCEgZoO1ZWrG2GCiWYyrpFzZQYnzMcClfAr9/RkcXVFtx8yH9cxyGT5KcWKxWDFYoInl+pVClQuyWpmBxjg4Kz5UJD5aBISMwdylIljyY0x+GWIAkeWL9lr/Yq6/LF7cVKwsqlxLVtasH4NsnMRGmGNIdSti8pUj4K01ycqHwW8a99NtbzkUX63rba+DR4DlpaU/iBTENJCsp5grxx6zrbEB8/qCgYET7/TRYHOh4WJ+sQKt7TqC6UqKt9SzbqGAelmeZvmIEaYHFzfFCSkoCCaxnAm+OJYs3q0iLp/cIMslWijKWoHpdWR47uX2qOkhzygJmMlVunBlfIh+31GWzDbQysxFipbFBJUPkACOfiIZmJKa9clW9+19GOQLAaBPLieWRZeo1uu7UBcuB6jIr6hCjfYF91hupBLLRTKUACquF92k5gKhdJawYrN02nYpSwu4uZ6veU51mRGgCXVzd8WDCwCaZx1WdtsjiTrpIdxjOSP7WC6ScnVkuqlnmGfDuDEWy3KqQnVj4oXiuRS1b/xBgZomfPsvgBFcolhm0ol/lUDrw4kazQe5x6BRfxiV/exICSi5G4IaI7ojur7s5P1inWyz4UBI4KDDCnBtFOnt89BLV8Vuc2RR769QDoIB/i+IklJ5gEluUl5Xg3h6uyJilBXL0oJ5u+eseILVJodykUSaN0pUYzHOgBnfOA9dp56S3AEEaHzvvkgWzFcZ7hEoIwYz5Xhjo/CNErZRAM0KsuK9QXloTMWSqug0rgX5/rJ7AU3+4jLMvfUWZDnZN/Lu+2pDNYm/f1TByywGkxoEOdgHSpBwSxmvHCemJ8S6sxJH8UfFPuqCm7CBzoUlMdDXLBmKx9rU2YlZqy/H7O9fkekI0uk/gPFdu6JbsATilMRiME9+BwVYIjkGo11lpQL9YpBf+t9kQefZ6CIBsNYWtC9ciOnnnYtpK/4WbQvS/y8fqg5u+QMCbxsYrJfVfYZQAjP50KYsyC6xxmLFLdVRZVY67IrLMHXl1xLZJQfQNHUKmmfOQMucOWieMb3irwrtX7tOBoaHGEWWGXt5SuRepM6NATJKgrVD+K0SVeepJyP9f+5SITkODqx/prROjBw9/57U1ISo5C6tgBGlzTKJkxv+DH9CV9BE18BzL2Bs2wdW16dZsATPfeIxmCcOBriz+5I9UyyWl1aCUYnHGootPjqKnl/cBea9fYdyjSmMHEUlZsE8IPzfA7rpQXNI/vameKyh2Opfsw5Dz28KXV6EMCklAphooZiaQ/17LoI6dfTZUHka3b4De668quhFEM56iaoaFymKmmYQXSUnyqkqJSd5w2JiyRkcxEervofCnr1WuNTAPo3H1RN7u44pSLQGk8r2pQNvKK54wcFH3/lHDL/0SmAca+uzpJS8BTPlBLhKyaC5K12fPy3J5tW9Cr29+PCiVRjcsLGYYJjvSjuwF5Xa+8F0s8zoA+byAQIAYwwzv3MxZq66OI3m1aWGX30NH5x5tg+XaVqChIvog6SU+BSzNCURIo+Kx6ZddCFm33hDI+IPIT4ygp6770XPTbfAyfcBMF3getwFoVxaSuUehurqpBzFVaqTsNMu+TZm/ewnYE1NaTStrtT/+BPY+8MbMLr1HQB0sG4bHZqWk1SqN8no0aIZsskrz8asn97QgMsiZ3AQ/euexP67f4nhN36nD6KokMNPz841ekoNMGluLARknWd9FbN/dU+m/8SzljTc/Sb6HluD/EOPYPzj3WRwrrq7MHFX2krfgsG1UBbIOs9Y3oBLkDM0hLFdH+LgW1sw8Mr/4MD6DRjbYX6eC9DdYli40oYsk3e0AqWZejDxoBg6ln0es//jl2CTOtJuStWJj4+jcGAATr4XB7e+i+G33sLB/9uKg2+/jdE/vQ9eKJCuzASXlm+AC0K5tBXqX8mUK/GBPPHdW2hvx6SVK9B0+GyprPrgHhiRBn1EyrW/ghhV1tzWOLJ12PieveDjY3AODGB8fy8KvXkU+vvhHDgAPjzs/iiDaZaFsjYqLGZ3SY8Y0467RGUCmCcPHvoFb9yQ7q4TebDke0tWMJlaPjlJHUjERvIyDZa0ri5HgMtk6bJQ5o9aiiNLOSzTA39Jhhvk3mDCN/3S6LT0fBl565ML6SEtHCWqXjWdni5gWhnqzTfSssEdittTN7ArAReQMWA+DIAVMg5oT7n626C0gVgfFwu7mcV09ZTK6PgxokKUFDtajidsuniMFHiUxVK/TVZNBo94i06F4AIqZcE8uQfuKIF/Ma9kzSSA3O1EOK3WScuQ0SEMX2gFbaMekwaWYVoB6ncIq1VcVtxiBWIuVRX9NYLk3igQCJdpsmZGiWRKFtNu2aKAp5eh9+CvG6YJolgtMV98UQkjtqsUXEAFAVNPLPXbScplitbM244B/m8sFZ40y+enafXJOw9ykeGtl7tumB4wusQAsFSXKJbJcp4rSJX9PRUUF2eArAiSxZq5K7RLNIgix1a/QZRrptJN6xoIhDv0vmX4iFEiqgsuoAoAA8JA5pYyWDMVND8zqmLMV5h2Q6VbLZdh5BnWapnArLSqAjCAgMxLVEpR1ox0jYYRp7G8oU1xFBYuWyxGAajGWv6yYQRaDaoawACDuzFaM7cAARpp0Yw7SV5GwALmx0xgFddrx2qJqirAPIWzZm4i13vNZJEAIiOlXpHaDjtU5LcAlpdeK1ZLVFUCBgRbsxKE7ly9ApoIqcn9eUZQ3B8XC4SVIbAPSjMF+MU04vaRUKbawfJUtYB5Iq2ZlyHmiQnQ7waIdcnbGZRSwB8cixG3j7Qy9v1Vk6oeMECBzJOBkGJZDzaDj4IMW5JSm2Rcl8JH4t6hsF4r7pBSTQAGGE5qwCQrXPfpjzxRKi/WSRhGdTfh2mPLJ4BSy5njsHD7rEbVDGCiNIsWRAiEWM0vb7BfBqsobmHsaLPBhAkqcd3kCq37rHLVJGCA3Oma64SaKJeT3Ki6IcEdVaW9w/XXHljjMIulqlWwPNUsYJ5MozRxUBl0n1IaJEBnLGwnRw7yQ0xj1LpqHjBRQVZNgszQi2HuPwbtn0wLmGS1NKmmVVeAeRI7yggM160aCEsXZ5+2WGwiQCWqLgETFXa0R026igoxjgi133oHSlXdA6bKENpHn3aIub+JpgkHmKqJDkDaSuX1TQ015KkBWEOpKgdge6Ub0VCdivPuHAcer3Q7GqpPMbDuHJizttINaag+NZpzrs8ddTC/iQO3VboxDdWXOHDbvIP57TkAGB9xrgPn3RVuU0N1I9493uFcB7ijyHnI58dG+dKGJWuoXHHgtrEOvnRePp8HiHnGbe1Tj252ctcx8L8EYydk3cCGalLbOfA4mLP2qIP5TWLG/wMe/9h09O44dAAAAABJRU5ErkJggg=="></image></g></symbol></svg>'</body></html>

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -478,7 +478,8 @@ def patch_wiki_page(requests_mock):
                       text=page)
 
 
-def test_get_wiki_page(patch_wiki_page):
+@pytest.mark.usefixtures("patch_wiki_page")
+def test_get_wiki_page():
     """
     Test using WikiReader to get a page.
 
@@ -490,3 +491,26 @@ def test_get_wiki_page(patch_wiki_page):
             [h.text for h in reader.page.xpath("//h1")])
     assert (reader.page.xpath("//span")[-1].text ==
             "Take your favorite fandoms with you and never miss a beat.")
+
+
+@pytest.mark.usefixtures("patch_wiki_page")
+def test_find_elements_with_matching_subelement():
+    """
+    Test that a list of elements with the correct content is returned.
+
+    The method is currently only tested using a query that returns a single
+    element, but it is ensured that the element is of the right type and has
+    the expected content.
+    """
+    reader = WikiReader("https://habitica.fandom.com/wiki/test_article")
+    quest_list = reader.find_elements_with_matching_subelement("ul",
+                                                               "(CURRENT)")
+    assert len(quest_list) == 1
+    assert quest_list[0].tag == "ul"
+
+    li_elements = quest_list[0].getchildren()
+    assert len(li_elements) == 8
+    assert li_elements[0].text == "(CURRENT) Robot (collection)"
+
+    for element in li_elements:
+        assert element.tag == "li"


### PR DESCRIPTION
Replace the old and flaky Google script for fetching the party description with adding the same functionality to the bot. It is automatically run every 6 hours, but can also be manually triggered by command `update-quest-queue` sent to the bot.

The quest queue is fetched from a Habitica Wiki page set in the configuration. An ordered list that contains the phrase "(CURRENT)" is identified from the page, and the contents of that list are set as the quest queue in the party description. All parts of the description before string "The Quest Queue " are left as is.

The first item in the list (the current quest) is listed as the "zeroth" quest. A timestamp of the last update is also included in the updated part of the description. See image below for an example.

![Example quest queue as set by the bot](https://i.imgur.com/Tv5LnzG.png)

Fixes #6
Fixes #7