### PR TITLE
Identify inactive members

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,7 @@ jobs:
         if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 habot tests
     - name: Lint with pylint
       run: |
         pylint habot tests --disable=fixme,duplicate-code

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+lint: pylint flake
+
+pylint:
+	pylint habot tests --disable=fixme,duplicate-code
+
+flake:
+	flake8 habot tests

--- a/conf/db.py
+++ b/conf/db.py
@@ -11,6 +11,7 @@ TABLES = {
         "displayname": "VARCHAR(255)",
         "loginname": "VARCHAR(255)",
         "birthday": "DATE",
+        "lastlogin": "DATE",
         }, "id"),
     "private_messages": ({
         "id": "VARCHAR(50)",

--- a/habot/functionality/inactive_members.py
+++ b/habot/functionality/inactive_members.py
@@ -1,0 +1,62 @@
+"""
+Functionality for handling inactive party members
+"""
+
+import datetime
+
+from conf.header import HEADER
+from habot.functionality.base import Functionality, requires_party_membership
+from habot.io.db import DBTool, DBSyncer
+from habot.io.messages import HabiticaMessager
+
+
+class ListInactiveMembers(Functionality):
+    """
+    Responds with a list of inactive party members.
+
+    A member is considered inactive if they have not logged in within the last
+    three months.
+    """
+
+    threshold = datetime.timedelta(days=30*3)
+
+    def __init__(self):
+        """
+        Initialize the class
+        """
+        self._db_syncer = DBSyncer(HEADER)
+        self._db_tool = DBTool()
+        self._messager = HabiticaMessager(HEADER)
+        super().__init__()
+
+    @requires_party_membership
+    def act(self, message):
+        self._db_syncer.update_partymember_data()
+        member_data = self._db_tool.get_partymember_data()
+        now = datetime.date.today()
+
+        inactive_members = []
+        for member in member_data:
+            if now - member["lastlogin"] > self.threshold:
+                inactive_members.append(member)
+
+        return self._construct_message(inactive_members)
+
+    def _construct_message(self, inactive_users):
+        """
+        Construct a report of inactive users
+        """
+        # pylint: disable=no-self-use
+        if not inactive_users:
+            return "No inactive members found!"
+
+        header = "The following party members are inactive:\n"
+        user_list = "\n".join(
+                [
+                    f"- @{user['loginname']} "
+                    f"(last login {str(user['lastlogin'])})"
+                    for user in inactive_users
+                    ]
+                )
+
+        return header + user_list

--- a/habot/functionality/react.py
+++ b/habot/functionality/react.py
@@ -12,6 +12,7 @@ from habot.functionality.quests import ListOwnedQuests, SendQuestReminders
 from habot.functionality.sharing_weekend_challenge import (
         SendWinnerMessage, CreateNextSharingWeekend, AwardWinner)
 from habot.functionality.tasks import AddTask
+from habot.functionality.inactive_members import ListInactiveMembers
 from habot.io.messages import HabiticaMessager
 import habot.logger
 from habot.message import PrivateMessage
@@ -61,6 +62,7 @@ def react_to_message(message):
         "party-newsletter": SendPartyNewsletter,
         "owned-quests": ListOwnedQuests,
         "update-party-description": UpdatePartyDescription,
+        "list-inactive-members": ListInactiveMembers,
         }
     first_word = message.content.strip().split()[0]
     logger.debug("Got message starting with %s", first_word)

--- a/habot/io/db.py
+++ b/habot/io/db.py
@@ -75,6 +75,7 @@ class DBSyncer():
                 "displayname": member.displayname,
                 "loginname": member.login_name,
                 "birthday": member.habitica_birthday,
+                "lastlogin": member.last_login,
                 }
             user_row = self._db.query_table(
                 "members", condition=f"id='{member.id}'")

--- a/habot/io/db.py
+++ b/habot/io/db.py
@@ -135,6 +135,9 @@ class DBTool():
             raise ValueError(f"User with user ID {uid} not found")
         return members[0]["loginname"]
 
+    def get_partymember_data(self):
+        return self._db.query_table("members")
+
 
 class DBOperator():
     """

--- a/habot/io/db.py
+++ b/habot/io/db.py
@@ -136,6 +136,9 @@ class DBTool():
         return members[0]["loginname"]
 
     def get_partymember_data(self):
+        """
+        Return the full partymember data as a list of dicts
+        """
         return self._db.query_table("members")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,25 +169,33 @@ def testdata_db_operator(purge_and_init_memberdata_fx):
 SIMPLE_USER = {"id": "9cb40345-720f-4c9e-974d-18e016d9564d",
                "displayname": "testuser",
                "loginname": "testuser",
-               "birthday": datetime.date(2016, 12, 4)}
+               "birthday": datetime.date(2016, 12, 4),
+               "lastlogin": datetime.date(2021, 1, 4),
+               }
 
 # User wth different display and login names
 NAMEDIFF_USER = {"id": "a431b1a5-d287-4c34-93c4-7d607905a947",
                  "displayname": "habitician",
                  "loginname": "habiticianlogin",
-                 "birthday": datetime.date(2019, 5, 31)}
+                 "birthday": datetime.date(2019, 5, 31),
+                 "lastlogin": datetime.date(2019, 6, 3),
+                 }
 
 # User with non-ascii characters in displayname
 CHARSET_USER = {"id": "7319d61c-1940-460d-8dc8-007f7e9537f0",
                 "displayname": "somedüde",
                 "loginname": "somedude",
-                "birthday": datetime.date(2019, 5, 31)}
+                "birthday": datetime.date(2019, 5, 31),
+                "lastlogin": datetime.date(2020, 12, 24),
+                }
 
 # User sharing a birthday with another user
 SHAREBDAY_USER = {"id": "b5845235-a344-4f52-a08b-02084cab00c4",
                   "displayname": "showingYaMyBDAY",
                   "loginname": "birthdayfella",
-                  "birthday": datetime.date(2019, 5, 31)}
+                  "birthday": datetime.date(2019, 5, 31),
+                  "lastlogin": datetime.date(2021, 1, 6),
+                  }
 
 ALL_USERS = [SIMPLE_USER, NAMEDIFF_USER, CHARSET_USER, SHAREBDAY_USER]
 
@@ -207,7 +215,7 @@ def purge_and_init_memberdata_fx(db_connection_fx):
         operator._ensure_tables()  # pylint: disable=protected-access
         cursor.execute("USE habdb")
         cursor.execute("INSERT INTO members "
-                       "(id, displayname, loginname, birthday) "
+                       "(id, displayname, loginname, birthday, lastlogin) "
                        "values "
                        f"{_member_dict_to_values(SIMPLE_USER)}, "
                        f"{_member_dict_to_values(NAMEDIFF_USER)}, "
@@ -223,7 +231,9 @@ def _member_dict_to_values(member_dict):
     Return a string that represents the given member dict for INSERT statement
     """
     return (f"('{member_dict['id']}', '{member_dict['displayname']}', "
-            f"'{member_dict['loginname']}', '{member_dict['birthday']}')")
+            f"'{member_dict['loginname']}', '{member_dict['birthday']}', "
+            f"'{member_dict['lastlogin']}')"
+            )
 
 
 @pytest.fixture

--- a/tests/db_test.py
+++ b/tests/db_test.py
@@ -186,7 +186,9 @@ def test_delete_illegal_row(testdata_db_operator):
           "loginname": {"Type": "varchar(255)", "Null": "YES", "Key": "",
                         "Default": None, "Extra": ""},
           "birthday": {"Type": "date", "Null": "YES", "Key": "",
-                       "Default": None, "Extra": ""}
+                       "Default": None, "Extra": ""},
+          "lastlogin": {"Type": "date", "Null": "YES", "Key": "",
+                        "Default": None, "Extra": ""},
           }),
     ]
 )

--- a/tests/functionality/inactive_members_test.py
+++ b/tests/functionality/inactive_members_test.py
@@ -1,0 +1,55 @@
+"""
+Test functionality related to inactive partymembers
+"""
+
+from freezegun import freeze_time
+import pytest
+
+from habot.functionality.inactive_members import ListInactiveMembers
+from habot.message import PrivateMessage
+from tests.conftest import SIMPLE_USER
+
+
+def inactive_members_message():
+    test_message = PrivateMessage(SIMPLE_USER["id"], "to_id",
+                                  content="list-inactive-members")
+    lister = ListInactiveMembers()
+    return lister.act(test_message)
+
+
+@freeze_time("2021-01-06")
+@pytest.mark.usefixtures("db_connection_fx", "no_db_update")
+def test_list_inactive_members_single(purge_and_init_memberdata_fx):
+    """
+    Test listing inactive members when there's one inactive member
+    """
+    purge_and_init_memberdata_fx()
+    response = inactive_members_message()
+
+    assert response == ("The following party members are inactive:\n"
+                        "- @habiticianlogin (last login 2019-06-03)")
+
+
+@freeze_time("2018-01-01")
+@pytest.mark.usefixtures("db_connection_fx", "no_db_update")
+def test_list_inactive_members_none(purge_and_init_memberdata_fx):
+    """
+    Test listing inactive members when there are no inactive members
+    """
+    purge_and_init_memberdata_fx()
+    response = inactive_members_message()
+
+    assert response == "No inactive members found!"
+
+
+@freeze_time("2022-01-01")
+@pytest.mark.usefixtures("db_connection_fx", "no_db_update")
+def test_list_inactive_members_many(purge_and_init_memberdata_fx):
+    """
+    Test listing inactive members when all members are inactive
+    """
+    purge_and_init_memberdata_fx()
+    response = inactive_members_message()
+
+    assert len(response.split("\n")) == 5  # 4 members + header
+    assert "- @testuser (last login 2021-01-04)" in response

--- a/tests/functionality/inactive_members_test.py
+++ b/tests/functionality/inactive_members_test.py
@@ -11,6 +11,9 @@ from tests.conftest import SIMPLE_USER
 
 
 def inactive_members_message():
+    """
+    Run ListInactiveMembers and return the resulting message
+    """
     test_message = PrivateMessage(SIMPLE_USER["id"], "to_id",
                                   content="list-inactive-members")
     lister = ListInactiveMembers()

--- a/tests/io/db_test.py
+++ b/tests/io/db_test.py
@@ -317,6 +317,7 @@ MEMBER_ALREADY_IN_DB_1 = Member(
                       "displayname": "member 1",
                       "loginname": "member1",
                       "birthday": datetime.date(2020, 1, 15),
+                      "last_login": datetime.date(2020, 12, 10),
                       })
 MEMBER_ALREADY_IN_DB_2 = Member(
         "member-already-in-db-2-id",
@@ -324,6 +325,7 @@ MEMBER_ALREADY_IN_DB_2 = Member(
                       "displayname": "member 2",
                       "loginname": "member2",
                       "birthday": datetime.date(2019, 6, 30),
+                      "last_login": datetime.date(2021, 1, 3),
                       })
 NEW_MEMBER = Member(
         "new-member-id",
@@ -331,6 +333,7 @@ NEW_MEMBER = Member(
                       "displayname": "New member =3",
                       "loginname": "newmember",
                       "birthday": datetime.date(2020, 12, 13),
+                      "last_login": datetime.date(2020, 12, 14),
                       })
 
 
@@ -351,6 +354,7 @@ def purge_and_set_memberdata_fx(db_connection_fx, db_operator_fx):
             "displayname": member.displayname,
             "loginname": member.login_name,
             "birthday": member.habitica_birthday,
+            "lastlogin": member.last_login,
             }
         db_operator_fx.insert_data("members", data)
 


### PR DESCRIPTION
Make the bot respond to comand `list-inactive-members` by sending back a list of all party members who have not logged in within the last 90 days.