### PR TITLE
Make it possible to ignore certain users when checking who is inactive

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -60,17 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
+disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
         file-ignored,
@@ -78,67 +68,8 @@ disable=print-statement,
         useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
         buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape
+	useless-option-value,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -475,13 +406,6 @@ max-line-length=100
 
 # Maximum number of lines in a module.
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/conf/inactive_members.py
+++ b/conf/inactive_members.py
@@ -1,0 +1,9 @@
+"""
+Here it is possible to disable inactivity reminders and removing from party for
+some party members.
+"""
+
+# list of Habitica users who will not be kicked from the party even if
+# inactive. E.g.
+# ALLOW_INACTIVITY_FROM = ["@someHabiticaUser", "@someoneElse"]
+ALLOW_INACTIVITY_FROM = []

--- a/habot/functionality/inactive_members.py
+++ b/habot/functionality/inactive_members.py
@@ -37,10 +37,13 @@ class ListInactiveMembers(Functionality):
         """
         return ALLOW_INACTIVITY_FROM
 
-    @requires_party_membership
-    def act(self, message):
-        self._db_syncer.update_partymember_data()
-        member_data = self._db_tool.get_partymember_data()
+    def inactive_members(self, member_data):
+        """
+        Return a list of inactive members
+
+        Members on the list of allowed inactive members are not included in the
+        list.
+        """
         now = datetime.date.today()
 
         inactive_members = []
@@ -49,7 +52,14 @@ class ListInactiveMembers(Functionality):
                 if member["loginname"] in self.allowed_inactive_members:
                     continue
                 inactive_members.append(member)
+        return inactive_members
 
+    @requires_party_membership
+    def act(self, message):
+        self._db_syncer.update_partymember_data()
+        member_data = self._db_tool.get_partymember_data()
+
+        inactive_members = self.inactive_members(member_data)
         return self._construct_message(inactive_members)
 
     def _construct_message(self, inactive_users):

--- a/habot/functionality/inactive_members.py
+++ b/habot/functionality/inactive_members.py
@@ -5,6 +5,7 @@ Functionality for handling inactive party members
 import datetime
 
 from conf.header import HEADER
+from conf.inactive_members import ALLOW_INACTIVITY_FROM
 from habot.functionality.base import Functionality, requires_party_membership
 from habot.io.db import DBTool, DBSyncer
 from habot.io.messages import HabiticaMessager
@@ -29,6 +30,13 @@ class ListInactiveMembers(Functionality):
         self._messager = HabiticaMessager(HEADER)
         super().__init__()
 
+    @property
+    def allowed_inactive_members(self):
+        """
+        Return list of allowed inactive members from confs
+        """
+        return ALLOW_INACTIVITY_FROM
+
     @requires_party_membership
     def act(self, message):
         self._db_syncer.update_partymember_data()
@@ -38,6 +46,8 @@ class ListInactiveMembers(Functionality):
         inactive_members = []
         for member in member_data:
             if now - member["lastlogin"] > self.threshold:
+                if member["loginname"] in self.allowed_inactive_members:
+                    continue
                 inactive_members.append(member)
 
         return self._construct_message(inactive_members)

--- a/habot/io/wiki.py
+++ b/habot/io/wiki.py
@@ -52,7 +52,7 @@ class WikiReader():
             :HTTPError: if the page cannot be fetched
             :WikiParsingError: if the page content cannot be found
         """
-        response = requests.get(self.url)
+        response = requests.get(self.url, timeout=5)
         response.raise_for_status()
         full_page_tree = etree.parse(StringIO(str(response.content)),
                                      self._parser)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 click
 cssselect
 freezegun
-git+git://github.com/aajarven/habitica-helper.git#egg=habitica-helper
+git+https://github.com/aajarven/habitica-helper.git#egg=habitica-helper
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib

--- a/tests/functionality/inactive_members_test.py
+++ b/tests/functionality/inactive_members_test.py
@@ -56,3 +56,21 @@ def test_list_inactive_members_many(purge_and_init_memberdata_fx):
 
     assert len(response.split("\n")) == 5  # 4 members + header
     assert "- @testuser (last login 2021-01-04)" in response
+
+
+@freeze_time("2022-01-01")
+@pytest.mark.usefixtures("db_connection_fx", "no_db_update")
+def test_list_inactive_members_allowlist(purge_and_init_memberdata_fx,
+                                         monkeypatch):
+    """
+    Test listing inactive members when all members are inactive
+    """
+    monkeypatch.setattr(ListInactiveMembers, "allowed_inactive_members",
+                        ["habiticianlogin", "testuser"])
+
+    purge_and_init_memberdata_fx()
+    response = inactive_members_message()
+
+    assert len(response.split("\n")) == 3  # 2 members + header
+    assert "@habiticianlogin" not in response
+    assert "@testuser" not in response


### PR DESCRIPTION
Anyone listed in `conf/inactive_members.py` is not listed as inactive nor later removed from the party.