### PR TITLE
Send a PM when removing a member from the party due to inactivity

### DIFF
--- a/habot/functionality/inactive_members.py
+++ b/habot/functionality/inactive_members.py
@@ -144,6 +144,8 @@ class RemoveInactiveMembers(Functionality):
             response.status_code,
         )
 
+        self._messager.send_private_message(id_, removal_message)
+
     @requires_admin_status
     def act(self, message):
         """

--- a/tests/functionality/inactive_members_test.py
+++ b/tests/functionality/inactive_members_test.py
@@ -100,9 +100,11 @@ def mock_delete_member():
 
 
 @freeze_time("2021-03-01")
-@pytest.mark.usefixtures("db_connection_fx", "no_db_update")
+@pytest.mark.usefixtures("db_connection_fx", "no_db_update",
+                         "mock_send_private_message_fx")
 def test_remove_inactive_members_allowlist(purge_and_init_memberdata_fx,
-                                           monkeypatch, mock_delete_member):
+                                           monkeypatch, mock_delete_member,
+                                           mock_send_private_message_fx):
     """
     Test removing inactive members
     """
@@ -122,3 +124,7 @@ def test_remove_inactive_members_allowlist(purge_and_init_memberdata_fx,
     assert "@testuser" not in response
 
     assert mock_delete_member.call_count == 1
+
+    pm_args = mock_send_private_message_fx.call_args_list
+    assert len(pm_args) == 1
+    assert pm_args[0][0][0] == "a431b1a5-d287-4c34-93c4-7d607905a947"


### PR DESCRIPTION
Now the same message is both broadcasted via the actual party member removal and sent as a PM to the member. This is due to it being hard to verify that the message provided to the API has actually been shown to the user, whereas a PM will leave a "paper trail".