### PR TITLE
Allow specific people to create challenges

### DIFF
--- a/conf/sharing_weekend.py
+++ b/conf/sharing_weekend.py
@@ -5,6 +5,8 @@ Data for creating and operating Sharing Weekend challenges.
 STOCK_DAY_NUMBER = 1  # Tuesday
 STOCK_NAME = "^AEX"
 
+CHALLENGE_ADMINS = []
+
 QUESTIONS_PATH = "data/weekly_questions.yml"
 
 SUMMARY = ("Each weekend (Sat/Sun/Mon) we look back and find positives "

--- a/habot/functionality/sharing_weekend_challenge.py
+++ b/habot/functionality/sharing_weekend_challenge.py
@@ -22,7 +22,12 @@ from habot import utils
 
 from conf.header import HEADER
 from conf.tasks import WINNER_PICKED
-from conf.sharing_weekend import STOCK_DAY_NUMBER, STOCK_NAME, QUESTIONS_PATH
+from conf.sharing_weekend import (
+        STOCK_DAY_NUMBER,
+        STOCK_NAME,
+        QUESTIONS_PATH,
+        CHALLENGE_ADMINS,
+        )
 
 
 class SendWinnerMessage(Functionality):
@@ -75,8 +80,9 @@ class CreateNextSharingWeekend(Functionality):
         """
         # pylint: disable=arguments-differ
 
-        if not scheduled_run and not self._sender_is_admin(message):
-            return "Only administrators are allowed to create new challenges."
+        if not scheduled_run and message.from_id not in CHALLENGE_ADMINS:
+            return ("Only challenge administrators are allowed to create new "
+                    "challenges.")
 
         tasks_path = "data/sharing_weekend_static_tasks.yml"
         self._logger.debug("create-next-sharing-weekend: tasks from %s, "
@@ -125,8 +131,9 @@ class AwardWinner(Functionality):
         """
         # pylint: disable=arguments-differ
 
-        if not scheduled_run and not self._sender_is_admin(message):
-            return "Only administrators are allowed to end challenges."
+        if not scheduled_run and message.from_id not in CHALLENGE_ADMINS:
+            return ("Only challenge administrators are allowed to end "
+                    "challenges.")
 
         challenge_id = self.partytool.current_sharing_weekend()["id"]
         challenge = Challenge(HEADER, challenge_id)


### PR DESCRIPTION
These "challenge admins" are listed in the configuration using their UIDs (specifically UIDs instead of usernames as attack via changing one's username would be possible in Habitica).