### PR TITLE
Add gem balance reporting

### DIFF
--- a/habot/functionality/gems.py
+++ b/habot/functionality/gems.py
@@ -22,3 +22,6 @@ class GemBalance(Functionality):
         Report the number of gems in the bot's wallet.
         """
         return f"I have {self.habitica_operator.gem_balance()} gems"
+
+    def help(self):
+        return "Reports the number of gems currently in the bot's wallet"

--- a/habot/functionality/gems.py
+++ b/habot/functionality/gems.py
@@ -2,7 +2,7 @@
 Functionality related to managing the gem balance of the bot.
 """
 
-from habot.functionality.base import Functionality
+from habot.functionality.base import Functionality, requires_party_membership
 from habot.habitica_operations import HabiticaOperator
 
 from conf.header import HEADER
@@ -17,6 +17,7 @@ class GemBalance(Functionality):
         self.habitica_operator = HabiticaOperator(HEADER)
         super().__init__()
 
+    @requires_party_membership
     def act(self, message):
         """
         Report the number of gems in the bot's wallet.

--- a/habot/functionality/gems.py
+++ b/habot/functionality/gems.py
@@ -1,0 +1,24 @@
+"""
+Functionality related to managing the gem balance of the bot.
+"""
+
+from habot.functionality.base import Functionality
+from habot.habitica_operations import HabiticaOperator
+
+from conf.header import HEADER
+
+
+class GemBalance(Functionality):
+    """
+    Report the current gem balance in wallet
+    """
+
+    def __init__(self):
+        self.habitica_operator = HabiticaOperator(HEADER)
+        super().__init__()
+
+    def act(self, message):
+        """
+        Report the number of gems in the bot's wallet.
+        """
+        return f"I have {self.habitica_operator.gem_balance()} gems"

--- a/habot/functionality/react.py
+++ b/habot/functionality/react.py
@@ -6,6 +6,7 @@ import re
 
 from habot.functionality.base import Ping
 from habot.functionality.birthdays import ListBirthdays
+from habot.functionality.gems import GemBalance
 from habot.functionality.newsletter import SendPartyNewsletter
 from habot.functionality.party_description import UpdatePartyDescription
 from habot.functionality.quests import ListOwnedQuests, SendQuestReminders
@@ -74,6 +75,7 @@ def react_to_message(message):
         "update-party-description": UpdatePartyDescription,
         "list-inactive-members": ListInactiveMembers,
         "remove-inactive-members": RemoveInactiveMembers,
+        "gem-balance": GemBalance,
         }
     first_word = message.content.strip().split()[0]
     logger.debug("Got message starting with %s", first_word)

--- a/habot/habitica_operations.py
+++ b/habot/habitica_operations.py
@@ -21,13 +21,28 @@ class HabiticaOperator():
     def __init__(self, header):
         self._header = header
         self._logger = habot.logger.get_logger()
+        self._user_data = None
 
-    def _get_user_data(self):
+    @property
+    def user_data(self):
         """
         Return the full user data dict.
         """
-        url = "https://habitica.com/api/v3/user"
-        return get_dict_from_api(self._header, url)
+        if not self._user_data:
+            url = "https://habitica.com/api/v3/user"
+            self._user_data = get_dict_from_api(self._header, url)
+
+        return self._user_data
+
+    def gem_balance(self):
+        """
+        Return the number of gems in wallet.
+
+        The nominal value for a gem is 0.25$, and the API reports the balance
+        in dollars, so the actual gem balance can be obtained by multiplying
+        the wallet balance by four.
+        """
+        return self.user_data["data"]["balance"] * 4
 
     def _get_tasks(self, task_type=None):
         """

--- a/habot/habitica_operations.py
+++ b/habot/habitica_operations.py
@@ -42,7 +42,7 @@ class HabiticaOperator():
         in dollars, so the actual gem balance can be obtained by multiplying
         the wallet balance by four.
         """
-        return self.user_data["data"]["balance"] * 4
+        return self.user_data["balance"] * 4
 
     def _get_tasks(self, task_type=None):
         """

--- a/habot/habitica_operations.py
+++ b/habot/habitica_operations.py
@@ -41,8 +41,11 @@ class HabiticaOperator():
         The nominal value for a gem is 0.25$, and the API reports the balance
         in dollars, so the actual gem balance can be obtained by multiplying
         the wallet balance by four.
+
+        The result is converted to int as at the moment Habitica does not
+        handle sub-gem amounts.
         """
-        return self.user_data["balance"] * 4
+        return int(self.user_data["balance"] * 4)
 
     def _get_tasks(self, task_type=None):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,14 +148,11 @@ def mock_user_data(requests_mock):
                       json={
                           "success": True,
                           "data": {
-                            "success": True,
-                            "data": {
-                                "auth": {
-                                    "local": {"username": "Botonbury"},
-                                    },
-                                "balance": 3.75
-                                }
-                             }
+                              "auth": {
+                                  "local": {"username": "Botonbury"},
+                                  },
+                              "balance": 3.75
+                              }
                           }
                       )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,27 @@ def mock_task_finding(requests_mock):
 
 
 @pytest.fixture()
+def mock_user_data(requests_mock):
+    """
+    Return standard test data for user
+    """
+    requests_mock.get("https://habitica.com/api/v3/user",
+                      json={
+                          "success": True,
+                          "data": {
+                            "success": True,
+                            "data": {
+                                "auth": {
+                                    "local": {"username": "Botonbury"},
+                                    },
+                                "balance": 3.75
+                                }
+                             }
+                          }
+                      )
+
+
+@pytest.fixture()
 def header_fx(test_credentials):
     """
     Return a header dict for testing.

--- a/tests/operations_test.py
+++ b/tests/operations_test.py
@@ -201,3 +201,11 @@ def test_gem_balance(test_operator):
     Test that correct gem balance is reported.
     """
     assert test_operator.gem_balance() == 15
+
+
+@pytest.mark.usefixtures("mock_user_data")
+def test_gem_balance_does_not_have_decimals(test_operator):
+    """
+    Ensure that gem balance does not contain decimal part
+    """
+    assert isinstance(test_operator.gem_balance(), int)

--- a/tests/operations_test.py
+++ b/tests/operations_test.py
@@ -193,3 +193,11 @@ def test_cron(mock_post, test_operator, header_fx):
     test_operator.cron()
     mock_post.assert_called_with("https://habitica.com/api/v3/cron",
                                  headers=header_fx)
+
+
+@pytest.mark.usefixtures("mock_user_data")
+def test_gem_balance(test_operator):
+    """
+    Test that correct gem balance is reported.
+    """
+    assert test_operator.gem_balance() == 15


### PR DESCRIPTION
Now the bot is able to report how many gems it has left. This is useful so that the people responsible for the automatically run challenges do not have to manually tally when they have to send more gems to the bot.