### PR TITLE
Allow all commands for the admin, even if not in party

### DIFF
--- a/habot/functionality/base.py
+++ b/habot/functionality/base.py
@@ -18,7 +18,10 @@ def requires_party_membership(act_function):
     def wrapper(self, message):
         partymember_uids = DBTool().get_party_user_ids()
 
-        if message.from_id not in partymember_uids:
+        if (
+                message.from_id not in partymember_uids
+                and message.from_id != conf.ADMIN_UID
+                ):
             # pylint: disable=protected-access
             self._logger.debug("Unauthorized %s request from %s",
                                message.content.strip().split()[0],


### PR DESCRIPTION
This allows testing the commands more freely, as well as e.g. running commands manually after the problem that caused automatic run to fail has been solved.