### PR TITLE
Allow sending more message parts at once, fix count in message

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,9 @@ jobs:
 
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/habot/io/messages.py
+++ b/habot/io/messages.py
@@ -97,8 +97,8 @@ class HabiticaMessager():
         """
         api_url = "https://habitica.com/api/v3/members/send-private-message"
         message_parts = self._split_long_message(message)
-        if len(message_parts) > 3:
-            raise SpamDetected(f"Sending {message_parts} messages at once is "
+        if len(message_parts) > 5:
+            raise SpamDetected(f"Sending {len(message_parts)} messages at once is "
                                "not supported.")
         for message_part in message_parts:
             try:

--- a/habot/io/messages.py
+++ b/habot/io/messages.py
@@ -98,8 +98,8 @@ class HabiticaMessager():
         api_url = "https://habitica.com/api/v3/members/send-private-message"
         message_parts = self._split_long_message(message)
         if len(message_parts) > 5:
-            raise SpamDetected(f"Sending {len(message_parts)} messages at once is "
-                               "not supported.")
+            raise SpamDetected(f"Sending {len(message_parts)} messages at "
+                               "once is not supported.")
         for message_part in message_parts:
             try:
                 habrequest.post(api_url, headers=self._header,


### PR DESCRIPTION
This allows sending really long messages, such as quest owner lists, without errors.